### PR TITLE
Actually use the generated global type variables for constructors

### DIFF
--- a/hphp/hack/src/typing/typing_classes_heap.ml
+++ b/hphp/hack/src/typing/typing_classes_heap.ml
@@ -416,11 +416,13 @@ module Api = struct
     | Lazy lc -> LSTable.get lc.ih.smethods id
     | Eager c -> SMap.find_opt id c.tc_smethods
 
-  let get_any_method ~is_static =
-    if is_static then
-      get_smethod
+  let get_any_method ~is_static cls id =
+    if String.equal id SN.Members.__construct then
+      fst (construct cls)
+    else if is_static then
+      get_smethod cls id
     else
-      get_method
+      get_method cls id
 
   let has_const t id =
     match t with

--- a/hphp/hack/src/typing/typing_print.ml
+++ b/hphp/hack/src/typing/typing_print.ml
@@ -342,7 +342,7 @@ module Full = struct
     | Toption x -> Concat [text "?"; k x]
     | Tlike x -> Concat [text "~"; k x]
     | Tprim x -> tprim x
-    | Tvar _ -> text "_"
+    | Tvar x -> text (Printf.sprintf "#%d" x)
     | Tfun ft -> tfun ~ty to_doc st env ft
     (* Don't strip_ns here! We want the FULL type, including the initial slash.
       *)

--- a/hphp/hack/test/tast/global_inference/params/type_hint_inferred_parameters_constructor.php
+++ b/hphp/hack/test/tast/global_inference/params/type_hint_inferred_parameters_constructor.php
@@ -1,0 +1,9 @@
+<?hh //partial
+
+class A {
+  public function __construct($x) {
+    foo($x);
+  }
+}
+
+function foo(int $x): void {}

--- a/hphp/hack/test/tast/global_inference/params/type_hint_inferred_parameters_constructor.php.exp
+++ b/hphp/hack/test/tast/global_inference/params/type_hint_inferred_parameters_constructor.php.exp
@@ -1,0 +1,68 @@
+[(Class
+    { c_span = [3:1-7:2]; c_annotation = (); c_mode = Mpartial;
+      c_final = false; c_is_xhp = false; c_has_xhp_keyword = false;
+      c_kind = Cnormal; c_name = ([3:7-8], "\\A");
+      c_tparams = { c_tparam_list = []; c_tparam_constraints = {} };
+      c_extends = []; c_uses = []; c_use_as_alias = [];
+      c_insteadof_alias = []; c_method_redeclarations = [];
+      c_xhp_attr_uses = []; c_xhp_category = None; c_reqs = [];
+      c_implements = []; c_where_constraints = []; c_consts = [];
+      c_typeconsts = []; c_vars = [];
+      c_methods =
+      [{ m_span = [4:3-6:4]; m_annotation = (); m_final = false;
+         m_abstract = false; m_static = false; m_visibility = Public;
+         m_name = ([4:19-30], "__construct"); m_tparams = [];
+         m_where_constraints = []; m_variadic = FVnonVariadic;
+         m_params =
+         [{ param_annotation = ([4:31-33], int);
+            param_type_hint = ((int), None); param_is_variadic = false;
+            param_pos = [4:31-33]; param_name = "$x"; param_expr = None;
+            param_callconv = None; param_user_attributes = [];
+            param_visibility = None }
+           ];
+         m_body =
+         { fb_ast =
+           [([5:5-13],
+             (Expr
+                (([5:5-12], void),
+                 (Call (Cnormal,
+                    (([5:5-8], (function(int $x): void)),
+                     (Id ([5:5-8], "\\foo"))),
+                    [], [(([5:9-11], int), (Lvar ([5:9-11], $x)))], None)))))
+             ];
+           fb_annotation = No unsafe blocks };
+         m_fun_kind = FSync; m_user_attributes = [];
+         m_ret = ((_), (Some ([4:19-30], (Hprim Tvoid))));
+         m_external = false; m_doc_comment = None }
+        ];
+      c_attributes = []; c_xhp_children = []; c_xhp_attrs = [];
+      c_namespace =
+      { Namespace_env.ns_ns_uses = <opaque>; ns_class_uses = <opaque>;
+        ns_record_def_uses = <opaque>; ns_fun_uses = <opaque>;
+        ns_const_uses = <opaque>; ns_name = None; ns_auto_ns_map = [];
+        ns_is_codegen = false };
+      c_user_attributes = []; c_file_attributes = []; c_enum = None;
+      c_pu_enums = []; c_doc_comment = None });
+  (Fun
+     { f_span = [9:1-30]; f_annotation = (); f_mode = Mpartial;
+       f_ret = ((void), (Some ([9:23-27], (Hprim Tvoid))));
+       f_name = ([9:10-13], "\\foo"); f_tparams = [];
+       f_where_constraints = []; f_variadic = FVnonVariadic;
+       f_params =
+       [{ param_annotation = ([9:18-20], int);
+          param_type_hint = ((int), (Some ([9:14-17], (Hprim Tint))));
+          param_is_variadic = false; param_pos = [9:18-20];
+          param_name = "$x"; param_expr = None; param_callconv = None;
+          param_user_attributes = []; param_visibility = None }
+         ];
+       f_body =
+       { fb_ast = [([Pos.none], Noop)]; fb_annotation = No unsafe blocks };
+       f_fun_kind = FSync; f_user_attributes = []; f_file_attributes = [];
+       f_external = false;
+       f_namespace =
+       { Namespace_env.ns_ns_uses = <opaque>; ns_class_uses = <opaque>;
+         ns_record_def_uses = <opaque>; ns_fun_uses = <opaque>;
+         ns_const_uses = <opaque>; ns_name = None; ns_auto_ns_map = [];
+         ns_is_codegen = false };
+       f_doc_comment = None; f_static = false })
+  ]

--- a/hphp/hack/test/tast/global_inference/params/type_hint_parameter_call.php
+++ b/hphp/hack/test/tast/global_inference/params/type_hint_parameter_call.php
@@ -1,0 +1,7 @@
+<?hh //partial
+
+function foo($x): void {
+    bar($x);
+}
+
+function bar(int $_): void {}

--- a/hphp/hack/test/tast/global_inference/params/type_hint_parameter_call.php.exp
+++ b/hphp/hack/test/tast/global_inference/params/type_hint_parameter_call.php.exp
@@ -1,0 +1,54 @@
+[(Fun
+    { f_span = [3:1-5:2]; f_annotation = (); f_mode = Mpartial;
+      f_ret = ((void), (Some ([3:19-23], (Hprim Tvoid))));
+      f_name = ([3:10-13], "\\foo"); f_tparams = [];
+      f_where_constraints = []; f_variadic = FVnonVariadic;
+      f_params =
+      [{ param_annotation = ([3:14-16], int);
+         param_type_hint = ((int), None); param_is_variadic = false;
+         param_pos = [3:14-16]; param_name = "$x"; param_expr = None;
+         param_callconv = None; param_user_attributes = [];
+         param_visibility = None }
+        ];
+      f_body =
+      { fb_ast =
+        [([4:5-13],
+          (Expr
+             (([4:5-12], void),
+              (Call (Cnormal,
+                 (([4:5-8], (function(int $_): void)),
+                  (Id ([4:5-8], "\\bar"))),
+                 [], [(([4:9-11], int), (Lvar ([4:9-11], $x)))], None)))))
+          ];
+        fb_annotation = No unsafe blocks };
+      f_fun_kind = FSync; f_user_attributes = []; f_file_attributes = [];
+      f_external = false;
+      f_namespace =
+      { Namespace_env.ns_ns_uses = <opaque>; ns_class_uses = <opaque>;
+        ns_record_def_uses = <opaque>; ns_fun_uses = <opaque>;
+        ns_const_uses = <opaque>; ns_name = None; ns_auto_ns_map = [];
+        ns_is_codegen = false };
+      f_doc_comment = None; f_static = false });
+  (Fun
+     { f_span = [7:1-30]; f_annotation = (); f_mode = Mpartial;
+       f_ret = ((void), (Some ([7:23-27], (Hprim Tvoid))));
+       f_name = ([7:10-13], "\\bar"); f_tparams = [];
+       f_where_constraints = []; f_variadic = FVnonVariadic;
+       f_params =
+       [{ param_annotation = ([7:18-20], int);
+          param_type_hint = ((int), (Some ([7:14-17], (Hprim Tint))));
+          param_is_variadic = false; param_pos = [7:18-20];
+          param_name = "$_"; param_expr = None; param_callconv = None;
+          param_user_attributes = []; param_visibility = None }
+         ];
+       f_body =
+       { fb_ast = [([Pos.none], Noop)]; fb_annotation = No unsafe blocks };
+       f_fun_kind = FSync; f_user_attributes = []; f_file_attributes = [];
+       f_external = false;
+       f_namespace =
+       { Namespace_env.ns_ns_uses = <opaque>; ns_class_uses = <opaque>;
+         ns_record_def_uses = <opaque>; ns_fun_uses = <opaque>;
+         ns_const_uses = <opaque>; ns_name = None; ns_auto_ns_map = [];
+         ns_is_codegen = false };
+       f_doc_comment = None; f_static = false })
+  ]

--- a/hphp/hack/test/tast/global_inference/params/type_hint_parameter_call_method.php
+++ b/hphp/hack/test/tast/global_inference/params/type_hint_parameter_call_method.php
@@ -1,0 +1,10 @@
+<?hh //partial
+
+class A {
+  public function foo($x): void {
+    bar($x);
+  }
+}
+
+function bar(int $_): void {
+}

--- a/hphp/hack/test/tast/global_inference/params/type_hint_parameter_call_method.php.exp
+++ b/hphp/hack/test/tast/global_inference/params/type_hint_parameter_call_method.php.exp
@@ -1,0 +1,68 @@
+[(Class
+    { c_span = [3:1-7:2]; c_annotation = (); c_mode = Mpartial;
+      c_final = false; c_is_xhp = false; c_has_xhp_keyword = false;
+      c_kind = Cnormal; c_name = ([3:7-8], "\\A");
+      c_tparams = { c_tparam_list = []; c_tparam_constraints = {} };
+      c_extends = []; c_uses = []; c_use_as_alias = [];
+      c_insteadof_alias = []; c_method_redeclarations = [];
+      c_xhp_attr_uses = []; c_xhp_category = None; c_reqs = [];
+      c_implements = []; c_where_constraints = []; c_consts = [];
+      c_typeconsts = []; c_vars = [];
+      c_methods =
+      [{ m_span = [4:3-6:4]; m_annotation = (); m_final = false;
+         m_abstract = false; m_static = false; m_visibility = Public;
+         m_name = ([4:19-22], "foo"); m_tparams = [];
+         m_where_constraints = []; m_variadic = FVnonVariadic;
+         m_params =
+         [{ param_annotation = ([4:23-25], int);
+            param_type_hint = ((int), None); param_is_variadic = false;
+            param_pos = [4:23-25]; param_name = "$x"; param_expr = None;
+            param_callconv = None; param_user_attributes = [];
+            param_visibility = None }
+           ];
+         m_body =
+         { fb_ast =
+           [([5:5-13],
+             (Expr
+                (([5:5-12], void),
+                 (Call (Cnormal,
+                    (([5:5-8], (function(int $_): void)),
+                     (Id ([5:5-8], "\\bar"))),
+                    [], [(([5:9-11], int), (Lvar ([5:9-11], $x)))], None)))))
+             ];
+           fb_annotation = No unsafe blocks };
+         m_fun_kind = FSync; m_user_attributes = [];
+         m_ret = ((void), (Some ([4:28-32], (Hprim Tvoid))));
+         m_external = false; m_doc_comment = None }
+        ];
+      c_attributes = []; c_xhp_children = []; c_xhp_attrs = [];
+      c_namespace =
+      { Namespace_env.ns_ns_uses = <opaque>; ns_class_uses = <opaque>;
+        ns_record_def_uses = <opaque>; ns_fun_uses = <opaque>;
+        ns_const_uses = <opaque>; ns_name = None; ns_auto_ns_map = [];
+        ns_is_codegen = false };
+      c_user_attributes = []; c_file_attributes = []; c_enum = None;
+      c_pu_enums = []; c_doc_comment = None });
+  (Fun
+     { f_span = [9:1-10:2]; f_annotation = (); f_mode = Mpartial;
+       f_ret = ((void), (Some ([9:23-27], (Hprim Tvoid))));
+       f_name = ([9:10-13], "\\bar"); f_tparams = [];
+       f_where_constraints = []; f_variadic = FVnonVariadic;
+       f_params =
+       [{ param_annotation = ([9:18-20], int);
+          param_type_hint = ((int), (Some ([9:14-17], (Hprim Tint))));
+          param_is_variadic = false; param_pos = [9:18-20];
+          param_name = "$_"; param_expr = None; param_callconv = None;
+          param_user_attributes = []; param_visibility = None }
+         ];
+       f_body =
+       { fb_ast = [([Pos.none], Noop)]; fb_annotation = No unsafe blocks };
+       f_fun_kind = FSync; f_user_attributes = []; f_file_attributes = [];
+       f_external = false;
+       f_namespace =
+       { Namespace_env.ns_ns_uses = <opaque>; ns_class_uses = <opaque>;
+         ns_record_def_uses = <opaque>; ns_fun_uses = <opaque>;
+         ns_const_uses = <opaque>; ns_name = None; ns_auto_ns_map = [];
+         ns_is_codegen = false };
+       f_doc_comment = None; f_static = false })
+  ]

--- a/hphp/hack/test/tast/global_inference/typeparams/type_hint_typeparameter_custom.php.exp
+++ b/hphp/hack/test/tast/global_inference/typeparams/type_hint_typeparameter_custom.php.exp
@@ -50,7 +50,7 @@ Errors:
              ];
            fb_annotation = No unsafe blocks };
          m_fun_kind = FSync; m_user_attributes = [];
-         m_ret = ((void), (Some ([5:19-30], (Hprim Tvoid))));
+         m_ret = ((_), (Some ([5:19-30], (Hprim Tvoid))));
          m_external = false; m_doc_comment = None }
         ];
       c_attributes = []; c_xhp_children = []; c_xhp_attrs = [];

--- a/hphp/hack/test/tast/global_inference/typeparams/type_hint_typeparameter_variance.php.exp
+++ b/hphp/hack/test/tast/global_inference/typeparams/type_hint_typeparameter_variance.php.exp
@@ -41,7 +41,7 @@ Errors:
          m_body =
          { fb_ast = [([Pos.none], Noop)]; fb_annotation = No unsafe blocks };
          m_fun_kind = FSync; m_user_attributes = [];
-         m_ret = ((void), (Some ([4:19-30], (Hprim Tvoid))));
+         m_ret = ((_), (Some ([4:19-30], (Hprim Tvoid))));
          m_external = false; m_doc_comment = None }
         ];
       c_attributes = []; c_xhp_children = []; c_xhp_attrs = [];


### PR DESCRIPTION
Summary: Fix a bug where we weren't using the global type variables generated for class constructor parameters.

Reviewed By: CatherineGasnier

Differential Revision: D19547208

fbshipit-source-id: 765cbc161e852f3674bef3163ed5055c535885ca