### PR TITLE
adding missing support in hhbc for PU

### DIFF
--- a/hphp/hack/src/hhbc/closure_convert.ml
+++ b/hphp/hack/src/hhbc/closure_convert.ml
@@ -1116,6 +1116,9 @@ and convert_hint env st ((p, h) as hint) =
   | Haccess _
   | Hfun _ ->
     (st, hint)
+  | Hpu_access (hint, name) ->
+    let (st, hint) = convert_hint env st hint in
+    (st, (p, Hpu_access (hint, name)))
   | _ ->
     failwith "TODO Unimplemented convert_hints hints not present in legacy AST"
 

--- a/hphp/hack/src/hhbc/emit_expression.ml
+++ b/hphp/hack/src/hhbc/emit_expression.ml
@@ -3232,6 +3232,9 @@ and fixup_type_arg (env : Emit_env.t) ~isas (hint : Aast.hint) =
           } )
     | Aast.Haccess _ -> (p, hint)
     | Aast.Hsoft h -> (p, Aast.Hsoft (aux h))
+    | Aast.Hpu_access (h, name) ->
+      let h = aux h in
+      (p, Aast.Hpu_access (h, name))
     | _ -> failwith "todo"
   and aux_sf sfi = { sfi with Aast.sfi_hint = aux sfi.Aast.sfi_hint } in
   aux hint

--- a/hphp/hack/test/pocket_universes/compile/closure.good.php
+++ b/hphp/hack/test/pocket_universes/compile/closure.good.php
@@ -1,0 +1,14 @@
+<?hh // strict
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+
+class C {
+  enum E {
+    case type T;
+    case ?(function(): Awaitable<?T>) generator;
+  }
+
+  public static function derive<TE as this:@Entry>(
+    TE $field, mixed $data) : void {
+      $_ = $data as ?this:@Entry:@TE:@T;
+    }
+}

--- a/hphp/hack/test/pocket_universes/compile/closure.good.php.exp
+++ b/hphp/hack/test/pocket_universes/compile/closure.good.php.exp
@@ -1,0 +1,46 @@
+# closure.good.php starts here
+
+.filepath "closure.good.php";
+
+.hh_file 1;
+.adata A_0 = """Y:1:{s:8:\"nullable\";b:1;}""";
+.adata A_1 = """v:0:{}""";
+
+.main {
+  DefCls 0
+  Int 1
+  RetC
+}
+
+.class C {
+  .method [public static] <"HH\\void" N  > derive(<"TE" "" extended_hint type_var > $field, <"HH\\mixed" N  > $data) {
+    .declvars $_;
+    VerifyParamType $field
+    CGetL $data
+    SetL _3
+    Array @A_0
+    SetL _4
+    IsTypeStructC Resolve
+    JmpNZ L0
+    PushL _3
+    PushL _4
+    ThrowAsTypeStructException
+  L0:
+    PushL _3
+    UnsetL _4
+    SetL $_
+    PopC
+    Null
+    RetC
+  }
+  .method [public static] <"HH\\mixed" N  > E##Members() {
+    .declvars $mems;
+    Vec @A_1
+    SetL $mems
+    PopC
+    CGetL $mems
+    RetC
+  }
+}
+
+# closure.good.php ends here


### PR DESCRIPTION
Summary: Adding some missing code for PU in a couple of mappers in hhbc.

Reviewed By: manzyuk

Differential Revision: D19619433

fbshipit-source-id: 344e4e5130f66de278dba292ae1d109e171b21fc