### PR TITLE
Disable serialization of optimized JITed code

### DIFF
--- a/hphp/runtime/base/runtime-option.h
+++ b/hphp/runtime/base/runtime-option.h
@@ -1017,7 +1017,7 @@ struct RuntimeOption {
   F(bool, JitSerdesModeForceOff,       false)                           \
   F(bool, JitDesUnitPreload,           false)                           \
   F(std::set<std::string>, JitSerdesDebugFunctions, {})                 \
-  F(uint32_t, JitSerializeOptProfSeconds, ServerExecutionMode() ? 300 : 0)\
+  F(uint32_t, JitSerializeOptProfSeconds,  0)                           \
   F(uint32_t, JitSerializeOptProfRequests, 0)                           \
   F(int, SimpleJsonMaxLength,        2 << 20)                           \
   F(uint32_t, JitSampleRate,               0)                           \


### PR DESCRIPTION
Summary:
It appears to be causing incorrect code to be JITed due to a bug in
instrumentation of vasm block counters.

Reviewed By: jano

Differential Revision: D19658220

fbshipit-source-id: ba8448c2cdcad167d616f13cfa404bcfd1e08ddd