### PR TITLE
Delete empty() expression leftovers from the runtime.

### DIFF
--- a/hphp/doc/bytecode.specification
+++ b/hphp/doc/bytecode.specification
@@ -749,7 +749,7 @@ The instruction set is organized into the following sections:
    3. Operator instructions
    4. Control flow instructions
    5. Get instructions
-   6. Isset, Empty and type querying instructions
+   6. Isset and type querying instructions
    7. Mutator instructions
    8. Call instructions
    9. Member operations
@@ -1491,7 +1491,7 @@ ClassGetTS                         [C:DArr]  ->  [C:Class, C:StaticVArr|Null]
   in RecordReifiedGeneric and pushed. If not present, null is pushed.
 
 
-6. Isset, Empty, and type querying instructions
+6. Isset and type querying instructions
 -----------------------------------------------
 
 IssetC    [C]  ->  [C:Bool]
@@ -1520,25 +1520,6 @@ IssetS    [C C:Class]  ->  [C:Bool]
   If class $1 does have an accessible property named x, this instruction reads
   the static property named x. If the static property is null, this instruction
   pushes false onto the stack, otherwise it pushes true.
-
-EmptyL <local variable id>     []  ->  [C:Bool]
-
-  Empty local. This instruction reads the local variable named %1 into x. If
-  the local variable is defined this instruction pushes !(x) onto the stack,
-  otherwise it pushes true.
-
-EmptyG    [C]  ->  [C:Bool]
-
-  Empty global. This instruction reads the global variable named (string)$1
-  into x. If the global variable is defined this instruction pushes !(x) onto
-  the stack, otherwise it pushes true.
-
-EmptyS    [C C:Class]  ->  [C:Bool]
-
-  Empty static property. This instruction first checks if $1 has an
-  accessible static property named (string)$2. If it doesn't, this instruction
-  pushes true, otherwise this instruction reads the static property into x and
-  pushes !(x) onto the stack.
 
 IsTypeC  <op>                     [C]  ->  [C:Bool]
 
@@ -2371,34 +2352,6 @@ IssetElemL <local variable id>    [B]  ->  [C:Bool]
   If y is a not a string, array, or object, this operation pushes false onto
   the stack.
 
-EmptyElemC                        [C B]  ->  [C]
-EmptyElemL <local variable id>    [B]  ->  [C]
-
-  Empty element.
-
-  These instructions first load a value into x and a base into y, as given by
-  the following table:
-
-         operation    x    y
-       ------------+----+-----
-        EmptyElemC | $2 | $1
-        EmptyElemL | %1 | $1
-
-  If y is an array, this operation pushes !(y[x]) onto the stack.
-
-  If y is an object that implements the ArrayAccess interface, this operation
-  first calls y->offsetExists(x); if that returns false this operation pushes
-  true onto the stack, otherwise it pushes !(y->offsetGet(x)) onto the stack.
-
-  If y is an object that does not implement the ArrayAccess interface, this
-  operation throws a fatal error.
-
-  If y is a string, this operation computes z = (int)x, then pushes true if (z
-  < 0 || z >= strlen(y)), !(y[z]) otherwise.
-
-  If y is, not an array, object, or string, this operation pushes true onto the
-  stack.
-
 SetElemC    [C C B]  ->  [C]
 
   Set element. If $1 is an array, this operation executes $1[$3] = $2 and then
@@ -2679,40 +2632,6 @@ IssetPropL <local variable id>    [B]  ->  [C:Bool]
 
   If y is not an object or array, this operation pushes false.
 
-EmptyPropC                        [C B]  ->  [C:Bool]
-EmptyPropL <local variable id>    [B]  ->  [C:Bool]
-
-  Empty property.
-
-  These instructions first load a value into x and a base into y, as given by
-  the following table:
-
-         operation     x    y
-       -------------+----+-----
-        EmptyPropC  | $2 | $1
-        EmptyPropL  | %1 | $1
-
-  If y is an object that does not have an eligible __isset method, this
-  operation first checks if y has a visible and accessible property named x.
-  If it does, this operation pushes !(y->x) onto the stack. Otherwise this
-  operation pushes true onto the stack.
-
-  If y is an object that has an eligible __isset method but it does not have an
-  eligible __get method, this operation checks if y has a visible and
-  accessible property named x. If it does, this operation pushes !(y->x) onto
-  the stack. Otherwise this operation pushes !(y->__isset(x)) onto the stack.
-
-  If y is an object that has an eligible __isset method and an eligible __get
-  method, this operation checks if y has a visible and accessible property
-  named x. If it does, this operation pushes !(y->x) onto the stack. Otherwise
-  this operation continues to execute x = y->__isset(x). If x is false this
-  operation pushes true onto the stack, otherwise this operation pushes
-  !(y->__get(x)) onto the stack.
-
-  If y is an array, this operation pushes !(y[x]) onto the stack.
-
-  If y is not an object or array, this operation pushes true.
-
 SetPropC                        [C C B]  ->  [C]
 SetPropL <local variable id>    [C B]  ->  [C]
 
@@ -2916,7 +2835,7 @@ result. These are elements read by Base*C instructions, and member keys.
 
 QueryM <stack count> <query op> <member key>    [...]  ->  [C]
 
-  {CGet,Isset,Empty}{Prop,Elem} member operation.
+  {CGet,Isset}{Prop,Elem} member operation.
 
 SetM <stack count> <member key>    [... C]  ->  [C]
 

--- a/hphp/doc/ir.specification
+++ b/hphp/doc/ir.specification
@@ -2892,10 +2892,6 @@ fields of that struct for holding intermediate values.
 
   Increment/decrement property with key S1 in base S0.
 
-| EmptyProp, D(Bool), S(Obj,LvalToCell) S(Cell), NF
-
-  Returns true iff the property with key S1 in base S0 is empty.
-
 | IssetProp, D(Bool), S(Obj,LvalToCell) S(Cell), NF
 
   Returns true iff the property with key S1 in base S0 is set.
@@ -3236,19 +3232,6 @@ fields of that struct for holding intermediate values.
 | IssetElem, D(Bool), S(LvalToCell) S(Cell), NF
 
   Returns true iff the element at key S1 in S0 is set.
-
-| EmptyElem, D(Bool), S(LvalToCell) S(Cell), NF
-
-  Returns true iff the element at key S1 in S0 is set and not equal (as defined
-  by the hhbc Eq instruction) to false.
-
-| DictEmptyElem, D(Bool), S(Dict) S(Int,Str), NF
-
-  Like EmptyElem, but specialized for dicts.
-
-| KeysetEmptyElem, D(Bool), S(Keyset) S(Int,Str), NF
-
-  Like EmptyElem, but specialized for dicts.
 
 | CheckRange, D(Bool), S(Int) S(Int), NF
 

--- a/hphp/hhbbc/dce.cpp
+++ b/hphp/hhbbc/dce.cpp
@@ -1562,9 +1562,6 @@ void dce(Env& env, const bc::DefClsNop& op) { no_dce(env, op); }
 void dce(Env& env, const bc::DefCns& op) { no_dce(env, op); }
 void dce(Env& env, const bc::DefRecord& op) { no_dce(env, op); }
 void dce(Env& env, const bc::DefTypeAlias& op) { no_dce(env, op); }
-void dce(Env& env, const bc::EmptyG& op) { no_dce(env, op); }
-void dce(Env& env, const bc::EmptyL& op) { no_dce(env, op); }
-void dce(Env& env, const bc::EmptyS& op) { no_dce(env, op); }
 void dce(Env& env, const bc::EntryNop& op) { no_dce(env, op); }
 void dce(Env& env, const bc::Eval& op) { no_dce(env, op); }
 void dce(Env& env, const bc::FCallBuiltin& op) { no_dce(env, op); }

--- a/hphp/hhbbc/interp-minstr.cpp
+++ b/hphp/hhbbc/interp-minstr.cpp
@@ -1506,10 +1506,6 @@ void in(ISS& env, const bc::QueryM& op) {
       case QueryMOp::Isset:
         miFinalIssetProp(env, nDiscard, *key);
         break;
-      case QueryMOp::Empty:
-        discard(env, nDiscard);
-        push(env, TBool);
-        break;
       case QueryMOp::InOut:
         always_assert(false);
     }
@@ -1529,15 +1525,6 @@ void in(ISS& env, const bc::QueryM& op) {
                         [](Type t) {
                           return t.subtypeOf(BInitNull) ? TFalse :
                             !t.couldBe(BInitNull) ? TTrue : TBool;
-                        });
-        break;
-      case QueryMOp::Empty:
-        miFinalCGetElem(env, nDiscard, *key, true,
-                        [](Type t) {
-                          auto const e = emptiness(t);
-                          return
-                            e == Emptiness::Empty ? TTrue :
-                            e == Emptiness::NonEmpty ? TFalse : TBool;
                         });
         break;
     }

--- a/hphp/hhbbc/interp.cpp
+++ b/hphp/hhbbc/interp.cpp
@@ -2861,18 +2861,6 @@ void in(ISS& env, const bc::IssetL& op) {
   push(env, TBool);
 }
 
-void in(ISS& env, const bc::EmptyL& op) {
-  nothrow(env);
-  constprop(env);
-  castBoolImpl(env, locAsCell(env, op.loc1), true);
-}
-
-void in(ISS& env, const bc::EmptyS& op) {
-  popC(env);
-  popC(env);
-  push(env, TBool);
-}
-
 void in(ISS& env, const bc::IssetS& op) {
   auto const tcls  = popC(env);
   auto const tname = popC(env);
@@ -2913,7 +2901,6 @@ void in(ISS& env, const bc::IssetS& op) {
   push(env, TBool);
 }
 
-void in(ISS& env, const bc::EmptyG&) { popC(env); push(env, TBool); }
 void in(ISS& env, const bc::IssetG&) { popC(env); push(env, TBool); }
 
 void isTypeImpl(ISS& env, const Type& locOrCell, const Type& test) {

--- a/hphp/hhbbc/optimize.cpp
+++ b/hphp/hhbbc/optimize.cpp
@@ -244,9 +244,6 @@ bool hasObviousStackOutput(const Bytecode& op, const Interp& interp) {
   case Op::IssetL:
   case Op::IssetG:
   case Op::IssetS:
-  case Op::EmptyL:
-  case Op::EmptyG:
-  case Op::EmptyS:
   case Op::IsTypeC:
   case Op::IsTypeL:
   case Op::OODeclExists:

--- a/hphp/runtime/base/collections.cpp
+++ b/hphp/runtime/base/collections.cpp
@@ -452,23 +452,6 @@ bool isset(ObjectData* obj, const TypedValue* key) {
   not_reached();
 }
 
-bool empty(ObjectData* obj, const TypedValue* key) {
-  switch (obj->collectionType()) {
-    case CollectionType::Vector:
-    case CollectionType::ImmVector:
-      return BaseVector::OffsetEmpty(obj, key);
-    case CollectionType::Map:
-    case CollectionType::ImmMap:
-      return BaseMap::OffsetEmpty(obj, key);
-    case CollectionType::Set:
-    case CollectionType::ImmSet:
-      return BaseSet::OffsetEmpty(obj, key);
-    case CollectionType::Pair:
-      return c_Pair::OffsetEmpty(obj, key);
-  }
-  not_reached();
-}
-
 void unset(ObjectData* obj, const TypedValue* key) {
   switch (obj->collectionType()) {
     case CollectionType::Vector:

--- a/hphp/runtime/base/collections.h
+++ b/hphp/runtime/base/collections.h
@@ -137,11 +137,9 @@ tv_lval atRw(ObjectData* obj, const TypedValue* key);
 /* Check for {key} within {obj} Collection
  * `contains` merely need to exist
  * `isset` needs to exist and not be null
- * `empty` needs to exist and not be falsy
  */
 bool contains(ObjectData* obj, const Variant& offset);
 bool (isset)(ObjectData* obj, const TypedValue* key);
-bool empty(ObjectData* obj, const TypedValue* key);
 
 /* Remove element {key} from Collection {obj} */
 void unset(ObjectData* obj, const TypedValue* key);

--- a/hphp/runtime/base/object-data.h
+++ b/hphp/runtime/base/object-data.h
@@ -528,8 +528,6 @@ struct ObjectData : Countable, type_scan::MarkCollectable<ObjectData> {
   tv_lval propImpl(TypedValue* tvRef, const Class* ctx,
                    const StringData* key, MInstrPropState* pState);
 
-  bool propEmptyImpl(const Class* ctx, const StringData* key);
-
   void setDynProp(const StringData* key, TypedValue val);
 
   bool invokeSet(const StringData* key, TypedValue val);
@@ -549,7 +547,6 @@ struct ObjectData : Countable, type_scan::MarkCollectable<ObjectData> {
                 const StringData* key, MInstrPropState* pState);
 
   bool propIsset(const Class* ctx, const StringData* key);
-  bool propEmpty(const Class* ctx, const StringData* key);
 
   void setProp(Class* ctx, const StringData* key, TypedValue val);
   tv_lval setOpProp(TypedValue& tvRef, Class* ctx, SetOpOp op,

--- a/hphp/runtime/ext/collections/ext_collections-map.cpp
+++ b/hphp/runtime/ext/collections/ext_collections-map.cpp
@@ -329,20 +329,6 @@ bool BaseMap::OffsetIsset(ObjectData* obj, const TypedValue* key) {
   return result ? !tvIsNull(result) : false;
 }
 
-bool BaseMap::OffsetEmpty(ObjectData* obj, const TypedValue* key) {
-  auto map = static_cast<BaseMap*>(obj);
-  TypedValue* result;
-  if (key->m_type == KindOfInt64) {
-    result = map->get(key->m_data.num);
-  } else if (isStringType(key->m_type)) {
-    result = map->get(key->m_data.pstr);
-  } else {
-    throwBadKeyType();
-    result = nullptr;
-  }
-  return result ? !tvToBool(*result) : true;
-}
-
 bool BaseMap::OffsetContains(ObjectData* obj, const TypedValue* key) {
   auto map = static_cast<BaseMap*>(obj);
   if (key->m_type == KindOfInt64) {

--- a/hphp/runtime/ext/collections/ext_collections-map.h
+++ b/hphp/runtime/ext/collections/ext_collections-map.h
@@ -118,7 +118,6 @@ public:
   static void OffsetSet(ObjectData* obj, const TypedValue* key,
                         const TypedValue* val);
   static bool OffsetIsset(ObjectData* obj, const TypedValue* key);
-  static bool OffsetEmpty(ObjectData* obj, const TypedValue* key);
   static bool OffsetContains(ObjectData* obj, const TypedValue* key);
   static void OffsetUnset(ObjectData* obj, const TypedValue* key);
 

--- a/hphp/runtime/ext/collections/ext_collections-pair.cpp
+++ b/hphp/runtime/ext/collections/ext_collections-pair.cpp
@@ -101,18 +101,6 @@ bool c_Pair::OffsetIsset(ObjectData* obj, const TypedValue* key) {
   return result ? !tvIsNull(result) : false;
 }
 
-bool c_Pair::OffsetEmpty(ObjectData* obj, const TypedValue* key) {
-  auto pair = static_cast<c_Pair*>(obj);
-  TypedValue* result;
-  if (key->m_type == KindOfInt64) {
-    result = pair->get(key->m_data.num);
-  } else {
-    throwBadKeyType();
-    result = nullptr;
-  }
-  return result ? !tvToBool(*result) : true;
-}
-
 bool c_Pair::OffsetContains(ObjectData* obj, const TypedValue* key) {
   auto pair = static_cast<c_Pair*>(obj);
   if (key->m_type == KindOfInt64) {

--- a/hphp/runtime/ext/collections/ext_collections-pair.h
+++ b/hphp/runtime/ext/collections/ext_collections-pair.h
@@ -96,7 +96,6 @@ struct c_Pair : ObjectData {
     return nullptr;
   }
   static bool OffsetIsset(ObjectData* obj, const TypedValue* key);
-  static bool OffsetEmpty(ObjectData* obj, const TypedValue* key);
   static bool OffsetContains(ObjectData* obj, const TypedValue* key);
   static bool Equals(const ObjectData* obj1, const ObjectData* obj2);
 

--- a/hphp/runtime/ext/collections/ext_collections-set.cpp
+++ b/hphp/runtime/ext/collections/ext_collections-set.cpp
@@ -343,18 +343,6 @@ bool BaseSet::OffsetIsset(ObjectData* obj, const TypedValue* key) {
   return false;
 }
 
-bool BaseSet::OffsetEmpty(ObjectData* obj, const TypedValue* key) {
-  auto set = static_cast<BaseSet*>(obj);
-  if (key->m_type == KindOfInt64) {
-    return set->contains(key->m_data.num) ? !tvToBool(*key) : true;
-  }
-  if (isStringType(key->m_type)) {
-    return set->contains(key->m_data.pstr) ? !tvToBool(*key) : true;
-  }
-  throwBadValueType();
-  return true;
-}
-
 bool BaseSet::OffsetContains(ObjectData* obj, const TypedValue* key) {
   auto set = static_cast<BaseSet*>(obj);
   if (key->m_type == KindOfInt64) {

--- a/hphp/runtime/ext/collections/ext_collections-set.h
+++ b/hphp/runtime/ext/collections/ext_collections-set.h
@@ -127,7 +127,6 @@ public:
     }
   }
   static bool OffsetIsset(ObjectData* obj, const TypedValue* key);
-  static bool OffsetEmpty(ObjectData* obj, const TypedValue* key);
   static bool OffsetContains(ObjectData* obj, const TypedValue* key);
   static void OffsetUnset(ObjectData* obj, const TypedValue* key);
 

--- a/hphp/runtime/ext/collections/ext_collections-vector.cpp
+++ b/hphp/runtime/ext/collections/ext_collections-vector.cpp
@@ -251,16 +251,6 @@ bool BaseVector::OffsetIsset(ObjectData* obj, const TypedValue* key) {
   return result ? !tvIsNull(*result) : false;
 }
 
-bool BaseVector::OffsetEmpty(ObjectData* obj, const TypedValue* key) {
-  if (UNLIKELY(key->m_type != KindOfInt64)) {
-    throwBadKeyType();
-    return false;
-  }
-  const auto vec = static_cast<BaseVector*>(obj);
-  const auto result = vec->get(key->m_data.num);
-  return result ? !tvToBool(*result) : true;
-}
-
 bool BaseVector::OffsetContains(ObjectData* obj, const TypedValue* key) {
   auto vec = static_cast<BaseVector*>(obj);
   if (key->m_type == KindOfInt64) {

--- a/hphp/runtime/ext/collections/ext_collections-vector.h
+++ b/hphp/runtime/ext/collections/ext_collections-vector.h
@@ -137,7 +137,6 @@ public:
     return nullptr;
   }
   static bool OffsetIsset(ObjectData* obj, const TypedValue* key);
-  static bool OffsetEmpty(ObjectData* obj, const TypedValue* key);
   static bool OffsetContains(ObjectData* obj, const TypedValue* key);
   static bool Equals(const ObjectData* obj1, const ObjectData* obj2);
 

--- a/hphp/runtime/ext/simplexml/ext_simplexml.cpp
+++ b/hphp/runtime/ext/simplexml/ext_simplexml.cpp
@@ -1683,13 +1683,6 @@ static Variant HHVM_METHOD(SimpleXMLElement, __set,
   return sxe_prop_dim_write(data, name, value, true, false, nullptr);
 }
 
-bool SimpleXMLElement_propEmpty(const ObjectData* this_,
-                                const StringData* key) {
-  auto data = Native::data<SimpleXMLElement>(const_cast<ObjectData*>(this_));
-  return !sxe_prop_dim_exists(data, Variant(key->toCppString()),
-                              true, true, false);
-}
-
 static int64_t HHVM_METHOD(SimpleXMLElement, count) {
   auto data = Native::data<SimpleXMLElement>(this_);
   return php_sxe_count_elements_helper(data);

--- a/hphp/runtime/ext/simplexml/ext_simplexml.h
+++ b/hphp/runtime/ext/simplexml/ext_simplexml.h
@@ -33,7 +33,6 @@ const Class* SimpleXMLElement_classof();
 const Class* SimpleXMLElementIterator_classof();
 const Class* SimpleXMLIterator_classof();
 
-bool SimpleXMLElement_propEmpty(const ObjectData* obj, const StringData* key);
 Variant SimpleXMLElement_objectCast(const ObjectData* obj, DataType type);
 xmlNodePtr SimpleXMLElement_exportNode(const Object& sxe);
 

--- a/hphp/runtime/vm/hhbc.h
+++ b/hphp/runtime/vm/hhbc.h
@@ -438,7 +438,6 @@ enum class MOpMode : uint8_t {
   OP(CGet)                                        \
   OP(CGetQuiet)                                   \
   OP(Isset)                                       \
-  OP(Empty)                                       \
   OP(InOut)
 
 enum class QueryMOp : uint8_t {
@@ -651,9 +650,6 @@ constexpr uint32_t kMaxConcatN = 4;
   O(IssetL,          ONE(LA),          NOV,             ONE(CV),    NF) \
   O(IssetG,          NA,               ONE(CV),         ONE(CV),    NF) \
   O(IssetS,          NA,               TWO(CV,CV),      ONE(CV),    NF) \
-  O(EmptyL,          ONE(LA),          NOV,             ONE(CV),    NF) \
-  O(EmptyG,          NA,               ONE(CV),         ONE(CV),    NF) \
-  O(EmptyS,          NA,               TWO(CV,CV),      ONE(CV),    NF) \
   O(IsTypeC,         ONE(OA(IsTypeOp)),ONE(CV),         ONE(CV),    NF) \
   O(IsTypeL,         TWO(LA,                                            \
                        OA(IsTypeOp)),  NOV,             ONE(CV),    NF) \
@@ -832,8 +828,7 @@ inline MOpMode getQueryMOpMode(QueryMOp op) {
   switch (op) {
     case QueryMOp::CGet:  return MOpMode::Warn;
     case QueryMOp::CGetQuiet:
-    case QueryMOp::Isset:
-    case QueryMOp::Empty: return MOpMode::None;
+    case QueryMOp::Isset: return MOpMode::None;
     case QueryMOp::InOut: return MOpMode::InOut;
   }
   always_assert(false);

--- a/hphp/runtime/vm/jit/dce.cpp
+++ b/hphp/runtime/vm/jit/dce.cpp
@@ -260,12 +260,10 @@ bool canDCE(IRInstruction* inst) {
   case DictGetQuiet:
   case DictGetK:
   case DictIsset:
-  case DictEmptyElem:
   case DictIdx:
   case KeysetGetQuiet:
   case KeysetGetK:
   case KeysetIsset:
-  case KeysetEmptyElem:
   case KeysetIdx:
   case VecFirst:
   case VecLast:
@@ -635,7 +633,6 @@ bool canDCE(IRInstruction* inst) {
   case UnsetProp:
   case SetOpProp:
   case IncDecProp:
-  case EmptyProp:
   case IssetProp:
   case ElemX:
   case ProfileMixedArrayAccess:
@@ -688,7 +685,6 @@ bool canDCE(IRInstruction* inst) {
   case PairIsset:
   case MapIsset:
   case IssetElem:
-  case EmptyElem:
   case ProfileArrayKind:
   case ProfileType:
   case ProfileCall:

--- a/hphp/runtime/vm/jit/ir-opcode.cpp
+++ b/hphp/runtime/vm/jit/ir-opcode.cpp
@@ -382,8 +382,6 @@ bool opcodeMayRaise(Opcode opc) {
   case ElemVecD:
   case ElemVecU:
   case ElemX:
-  case EmptyElem:
-  case EmptyProp:
   case EqArr:
   case EqDict:
   case EqObj:
@@ -676,7 +674,6 @@ bool opcodeMayRaise(Opcode opc) {
   case DefLabel:
   case DefFrameRelSP:
   case DefRegSP:
-  case DictEmptyElem:
   case DictFirst:
   case DictFirstKey:
   case DictGetK:
@@ -773,7 +770,6 @@ bool opcodeMayRaise(Opcode opc) {
   case JmpSwitchDest:
   case JmpZero:
   case JmpPlaceholder:
-  case KeysetEmptyElem:
   case KeysetFirst:
   case KeysetGetK:
   case KeysetGetQuiet:

--- a/hphp/runtime/vm/jit/irgen-types.cpp
+++ b/hphp/runtime/vm/jit/irgen-types.cpp
@@ -1684,18 +1684,6 @@ void emitIssetL(IRGS& env, int32_t id) {
   push(env, gen(env, IsNType, TNull, ld));
 }
 
-void emitEmptyL(IRGS& env, int32_t id) {
-  auto const ldPMExit = makePseudoMainExit(env);
-  auto const ld = ldLoc(env, id, ldPMExit, DataTypeSpecific);
-  if (ld->isA(TClsMeth)) {
-    PUNT(EmptyL_is_ClsMeth);
-  }
-  push(
-    env,
-    gen(env, XorBool, gen(env, ConvTVToBool, ld), cns(env, true))
-  );
-}
-
 SSATmp* isTypeHelper(IRGS& env, IsTypeOp subop, SSATmp* val) {
   switch (subop) {
     case IsTypeOp::VArray: /* intentional fallthrough */

--- a/hphp/runtime/vm/jit/memory-effects.cpp
+++ b/hphp/runtime/vm/jit/memory-effects.cpp
@@ -1432,11 +1432,9 @@ MemEffects memory_effects_impl(const IRInstruction& inst) {
 
   case DictGetQuiet:
   case DictIsset:
-  case DictEmptyElem:
   case DictIdx:
   case KeysetGetQuiet:
   case KeysetIsset:
-  case KeysetEmptyElem:
   case KeysetIdx:
   case AKExistsDict:
   case AKExistsKeyset:
@@ -1468,11 +1466,9 @@ MemEffects memory_effects_impl(const IRInstruction& inst) {
    * arbitrary heap locations.
    */
   case CGetElem:
-  case EmptyElem:
   case IssetElem:
   case CGetProp:
   case CGetPropQ:
-  case EmptyProp:
   case IssetProp:
     return may_load_store_kill(
       AHeapAny | all_pointees(inst),

--- a/hphp/runtime/vm/jit/minstr-helpers.h
+++ b/hphp/runtime/vm/jit/minstr-helpers.h
@@ -267,34 +267,30 @@ inline TypedValue incDecPropCO(Class* ctx, ObjectData* base, TypedValue key,
 
 //////////////////////////////////////////////////////////////////////
 
-#define ISSET_EMPTY_PROP_HELPER_TABLE(m)                \
-  /* name          keyType       useEmpty */            \
-  m(issetPropC,    KeyType::Any, false)                 \
-  m(issetPropCS,   KeyType::Str, false)                 \
-  m(issetPropCE,   KeyType::Any, true)                  \
-  m(issetPropCES,  KeyType::Str, true)                  \
+#define ISSET_PROP_HELPER_TABLE(m) \
+  /* name        keyType */        \
+  m(issetPropC,  KeyType::Any)     \
+  m(issetPropCS, KeyType::Str)     \
 
-#define X(nm, kt, useEmpty)                                             \
-/* This returns uint64_t to ensure all 64 bits of rax are valid. */     \
+#define X(nm, kt)                                                   \
+/* This returns uint64_t to ensure all 64 bits of rax are valid. */ \
 inline uint64_t nm(Class* ctx, tv_lval base, key_type<kt> key) {    \
-  return HPHP::IssetEmptyProp<useEmpty, kt>(ctx, base, key);            \
+  return HPHP::IssetProp<kt>(ctx, base, key);                       \
 }
-ISSET_EMPTY_PROP_HELPER_TABLE(X)
+ISSET_PROP_HELPER_TABLE(X)
 #undef X
 
-#define ISSET_EMPTY_OBJ_PROP_HELPER_TABLE(m)       \
-  /* name          keyType       useEmpty */       \
-  m(issetPropCEO,  KeyType::Any, true)             \
-  m(issetPropCEOS, KeyType::Str, true)             \
-  m(issetPropCO,   KeyType::Any, false)            \
-  m(issetPropCOS,  KeyType::Str, false)            \
+#define ISSET_OBJ_PROP_HELPER_TABLE(m) \
+  /* name         keyType */           \
+  m(issetPropCO,  KeyType::Any)        \
+  m(issetPropCOS, KeyType::Str)        \
 
-#define X(nm, kt, useEmpty)                                             \
-/* This returns uint64_t to ensure all 64 bits of rax are valid. */     \
-inline uint64_t nm(Class* ctx, ObjectData* base, key_type<kt> key) {    \
-  return IssetEmptyPropObj<useEmpty, kt>(ctx, base, key);               \
+#define X(nm, kt)                                                    \
+/* This returns uint64_t to ensure all 64 bits of rax are valid. */  \
+inline uint64_t nm(Class* ctx, ObjectData* base, key_type<kt> key) { \
+  return IssetPropObj<kt>(ctx, base, key);                           \
 }
-ISSET_EMPTY_OBJ_PROP_HELPER_TABLE(X)
+ISSET_OBJ_PROP_HELPER_TABLE(X)
 #undef X
 
 //////////////////////////////////////////////////////////////////////
@@ -819,44 +815,30 @@ ARRAY_ISSET_HELPER_TABLE(X)
 
 //////////////////////////////////////////////////////////////////////
 
-template<KeyType keyType, bool isEmpty>
-uint64_t dictIssetImpl(ArrayData* a, key_type<keyType> key) {
-  return IssetEmptyElemDict<isEmpty, keyType>(a, key);
-}
+#define DICT_ISSET_ELEM_HELPER_TABLE(m) \
+  /* name           keyType */          \
+  m(dictIssetElemS, KeyType::Str)       \
+  m(dictIssetElemI, KeyType::Int)       \
 
-#define DICT_ISSET_EMPTY_ELEM_HELPER_TABLE(m)         \
-  /* name              keyType      isEmpty */        \
-  m(dictIssetElemS,    KeyType::Str,  false)          \
-  m(dictIssetElemSE,   KeyType::Str,  true)           \
-  m(dictIssetElemI,    KeyType::Int,  false)          \
-  m(dictIssetElemIE,   KeyType::Int,  true)           \
-
-#define X(nm, keyType, isEmpty)                               \
-inline uint64_t nm(ArrayData* a, key_type<keyType> key) {     \
-  return dictIssetImpl<keyType, isEmpty>(a, key);             \
+#define X(nm, keyType)                                    \
+inline uint64_t nm(ArrayData* a, key_type<keyType> key) { \
+  return IssetElemDict<keyType>(a, key);                  \
 }
-DICT_ISSET_EMPTY_ELEM_HELPER_TABLE(X)
+DICT_ISSET_ELEM_HELPER_TABLE(X)
 #undef X
 
 //////////////////////////////////////////////////////////////////////
 
-template<KeyType keyType, bool isEmpty>
-uint64_t keysetIssetImpl(ArrayData* a, key_type<keyType> key) {
-  return IssetEmptyElemKeyset<isEmpty, keyType>(a, key);
-}
+#define KEYSET_ISSET_ELEM_HELPER_TABLE(m) \
+  /* name             keyType */          \
+  m(keysetIssetElemS, KeyType::Str)       \
+  m(keysetIssetElemI, KeyType::Int)       \
 
-#define KEYSET_ISSET_EMPTY_ELEM_HELPER_TABLE(m)         \
-  /* name                keyType      isEmpty */        \
-  m(keysetIssetElemS,    KeyType::Str,  false)          \
-  m(keysetIssetElemSE,   KeyType::Str,  true)           \
-  m(keysetIssetElemI,    KeyType::Int,  false)          \
-  m(keysetIssetElemIE,   KeyType::Int,  true)           \
-
-#define X(nm, keyType, isEmpty)                               \
-inline uint64_t nm(ArrayData* a, key_type<keyType> key) {     \
-  return keysetIssetImpl<keyType, isEmpty>(a, key);           \
+#define X(nm, keyType)                                    \
+inline uint64_t nm(ArrayData* a, key_type<keyType> key) { \
+  return IssetElemKeyset<keyType>(a, key);                \
 }
-KEYSET_ISSET_EMPTY_ELEM_HELPER_TABLE(X)
+KEYSET_ISSET_ELEM_HELPER_TABLE(X)
 #undef X
 
 //////////////////////////////////////////////////////////////////////
@@ -881,25 +863,17 @@ UNSET_ELEM_HELPER_TABLE(X)
 
 //////////////////////////////////////////////////////////////////////
 
-template <KeyType keyType, bool isEmpty>
-bool issetEmptyElemImpl(tv_lval base, key_type<keyType> key) {
-  return HPHP::IssetEmptyElem<isEmpty, keyType>(base, key);
-}
+#define ISSET_ELEM_HELPER_TABLE(m) \
+  /* name       keyType */         \
+  m(issetElemC, KeyType::Any)      \
+  m(issetElemI, KeyType::Int)      \
+  m(issetElemS, KeyType::Str)      \
 
-#define ISSET_EMPTY_ELEM_HELPER_TABLE(m)    \
-  /* name         keyType       isEmpty */  \
-  m(issetElemC,   KeyType::Any, false)      \
-  m(issetElemCE,  KeyType::Any,  true)      \
-  m(issetElemI,   KeyType::Int, false)      \
-  m(issetElemIE,  KeyType::Int,  true)      \
-  m(issetElemS,   KeyType::Str, false)      \
-  m(issetElemSE,  KeyType::Str,  true)      \
-
-#define X(nm, kt, isEmpty)                            \
-inline uint64_t nm(tv_lval base, key_type<kt> key) {  \
-  return issetEmptyElemImpl<kt, isEmpty>(base, key);  \
+#define X(nm, kt)                                    \
+inline uint64_t nm(tv_lval base, key_type<kt> key) { \
+  return HPHP::IssetElem<kt>(base, key);             \
 }
-ISSET_EMPTY_ELEM_HELPER_TABLE(X)
+ISSET_ELEM_HELPER_TABLE(X)
 #undef X
 
 //////////////////////////////////////////////////////////////////////

--- a/hphp/runtime/vm/jit/simplify.cpp
+++ b/hphp/runtime/vm/jit/simplify.cpp
@@ -3152,16 +3152,6 @@ SSATmp* hackArrIssetImpl(State& env, const IRInstruction* inst,
 }
 
 template <typename I, typename S>
-SSATmp* hackArrEmptyElemImpl(State& env, const IRInstruction* inst,
-                             I getInt, S getStr) {
-  return hackArrQueryImpl(
-    env, inst,
-    getInt, getStr,
-    [&] (tv_rval rval) { return cns(env, !rval || !tvToBool(rval.tv())); }
-  );
-}
-
-template <typename I, typename S>
 SSATmp* hackArrIdxImpl(State& env, const IRInstruction* inst,
                        I getInt, S getStr) {
   return hackArrQueryImpl(
@@ -3199,7 +3189,6 @@ SSATmp* simplify##Name(State& env, const IRInstruction* inst) {       \
 X(DictGet, Get, dictVal)
 X(DictGetQuiet, GetQuiet, dictVal)
 X(DictIsset, Isset, dictVal)
-X(DictEmptyElem, EmptyElem, dictVal)
 X(DictIdx, Idx, dictVal)
 X(AKExistsDict, AKExists, dictVal)
 
@@ -3221,7 +3210,6 @@ SSATmp* simplify##Name(State& env, const IRInstruction* inst) {       \
 X(KeysetGet, Get, keysetVal)
 X(KeysetGetQuiet, GetQuiet, keysetVal)
 X(KeysetIsset, Isset, keysetVal)
-X(KeysetEmptyElem, EmptyElem, keysetVal)
 X(KeysetIdx, Idx, keysetVal)
 X(AKExistsKeyset, AKExists, keysetVal)
 
@@ -3955,8 +3943,6 @@ SSATmp* simplifyWork(State& env, const IRInstruction* inst) {
   X(ArrayIsset)
   X(DictIsset)
   X(KeysetIsset)
-  X(DictEmptyElem)
-  X(KeysetEmptyElem)
   X(ArrayIdx)
   X(AKExistsArr)
   X(DictIdx)

--- a/hphp/runtime/vm/jit/translator.cpp
+++ b/hphp/runtime/vm/jit/translator.cpp
@@ -243,9 +243,6 @@ static const struct {
   { OpIssetL,      {Local,            Stack1,       OutBoolean      }},
   { OpIssetG,      {Stack1,           Stack1,       OutBoolean      }},
   { OpIssetS,      {StackTop2,        Stack1,       OutBoolean      }},
-  { OpEmptyL,      {Local,            Stack1,       OutBoolean      }},
-  { OpEmptyG,      {Stack1,           Stack1,       OutBoolean      }},
-  { OpEmptyS,      {StackTop2,        Stack1,       OutBoolean      }},
   { OpIsTypeC,     {Stack1|
                     DontGuardStack1,  Stack1,       OutBoolean      }},
   { OpIsTypeL,     {Local,            Stack1,       OutIsTypeL      }},
@@ -842,7 +839,6 @@ bool dontGuardAnyInputs(const NormalizedInstruction& ni) {
   case Op::AssertRATL:
   case Op::AssertRATStk:
   case Op::SetL:
-  case Op::EmptyL:
   case Op::CastBool:
   case Op::Same:
   case Op::NSame:
@@ -911,8 +907,6 @@ bool dontGuardAnyInputs(const NormalizedInstruction& ni) {
   case Op::Div:
   case Op::Double:
   case Op::Dup:
-  case Op::EmptyG:
-  case Op::EmptyS:
   case Op::FCallClsMethod:
   case Op::FCallClsMethodD:
   case Op::FCallClsMethodS:

--- a/hphp/runtime/vm/member-operations.cpp
+++ b/hphp/runtime/vm/member-operations.cpp
@@ -92,17 +92,6 @@ bool objOffsetIsset(ObjectData* base, TypedValue offset) {
   return result.m_data.num;
 }
 
-bool objOffsetEmpty(ObjectData* base, TypedValue offset) {
-  if (!objOffsetIsset(base, offset)) {
-    return true;
-  }
-
-  auto value = objOffsetGet(base, offset, false);
-  auto result = !tvToBool(value);
-  tvDecRefGen(value);
-  return result;
-}
-
 void objOffsetAppend(
   ObjectData* base,
   TypedValue* val,

--- a/hphp/runtime/vm/verifier/check-func.cpp
+++ b/hphp/runtime/vm/verifier/check-func.cpp
@@ -1568,7 +1568,6 @@ bool FuncChecker::checkRxOp(State* cur, PC pc, Op op) {
     case Op::CGetL2:
     case Op::PushL:
     case Op::IssetL:
-    case Op::EmptyL:
     case Op::SetL:
     case Op::SetOpL:
     case Op::IncDecL:
@@ -1776,7 +1775,6 @@ bool FuncChecker::checkRxOp(State* cur, PC pc, Op op) {
       // fallthrough
     case Op::CGetG:
     case Op::IssetG:
-    case Op::EmptyG:
     case Op::SetG:
     case Op::SetOpG:
     case Op::IncDecG:
@@ -1791,7 +1789,6 @@ bool FuncChecker::checkRxOp(State* cur, PC pc, Op op) {
       // fallthrough
     case Op::CGetS:
     case Op::IssetS:
-    case Op::EmptyS:
     case Op::SetS:
     case Op::SetOpS:
     case Op::IncDecS:


### PR DESCRIPTION
Summary:
Remove Empty* bytecodes, the Empty mode of QueryM, and supporting IRops.

Simplify away the empty part of various isset+empty minstr helpers and member operations.

Now that they're all dead, delete objOffsetEmpty, collections::empty and the supporting OffsetEmpty helpers on each collection type, ObjectData::propEmpty, and SimpleXMLElement_propEmpty.

Reviewed By: ricklavoie

Differential Revision: D19742158

fbshipit-source-id: 1a459041048f814b8be1ed504ab0effc77042d16