### PR TITLE
Clean up Typing_arrays.union_{keys,values}

### DIFF
--- a/hphp/hack/src/typing/typing_arrays.ml
+++ b/hphp/hack/src/typing/typing_arrays.ml
@@ -65,22 +65,6 @@ class virtual downcast_tabstract_to_array_type_mapper =
     method virtual on_type : env -> locl_ty -> result
   end
 
-let union env tyl =
-  match tyl with
-  | [] -> Env.fresh_type env Pos.none (* TODO: position *)
-  | ty :: tyl' -> List.fold_left_env env tyl' ~init:ty ~f:TUtils.union
-
-let union_keys = union
-
-let union_values env values =
-  let unknown =
-    List.find values (fun ty ->
-        TUtils.is_sub_type_for_union env (mk (Reason.none, make_tany ())) ty)
-  in
-  match unknown with
-  | Some ty -> (env, mk (get_reason ty, TUtils.tany env))
-  | None -> union env values
-
 (* Apply this function to a type after lvalue array access that should update
  * array type (e.g from AKempty to AKdarray after using it as a dict). *)
 let update_array_type p ~is_map env ty =

--- a/hphp/hack/src/typing/typing_shapes.ml
+++ b/hphp/hack/src/typing/typing_shapes.ml
@@ -295,7 +295,7 @@ let to_collection env shape_ty res return_type =
 
       inherit! Type_mapper.tvar_expanding_type_mapper
 
-      method! on_tshape env _r shape_kind fdm =
+      method! on_tshape env r shape_kind fdm =
         match shape_kind with
         | Closed_shape ->
           let keys = ShapeMap.keys fdm in
@@ -319,10 +319,10 @@ let to_collection env shape_ty res return_type =
                     | None -> (env, mk (Reason.Rwitness p, TUtils.tany env))
                   end)
           in
-          let (env, key) = Typing_arrays.union_keys env keys in
+          let (env, key) = Typing_union.union_list env r keys in
           let values = ShapeMap.values fdm in
           let values = List.map ~f:(fun { sft_ty; _ } -> sft_ty) values in
-          let (env, value) = Typing_arrays.union_values env values in
+          let (env, value) = Typing_union.union_list env r values in
           return_type env (get_reason res) key value
         | Open_shape -> (env, res)
 


### PR DESCRIPTION
Summary: We have helper functions for unioning types that perform simplifications.

Reviewed By: vassilmladenov

Differential Revision: D19721548

fbshipit-source-id: a8a1e55ebdca7c9d38304657826cfbe118974e7f