### PR TITLE
Avoid accumulating Hhbc_options

### DIFF
--- a/hphp/hack/src/hhbc/compile.mli
+++ b/hphp/hack/src/hhbc/compile.mli
@@ -11,6 +11,7 @@ type result = {
   parsing_t: float;
   codegen_t: float;
   printing_t: float;
+  hhbc_options: Hhbc_options.t;
 }
 
 type env = {

--- a/hphp/hack/src/hhbc/hhbc_options.ml
+++ b/hphp/hack/src/hhbc/hhbc_options.ml
@@ -661,10 +661,6 @@ let override_from_cli config_list init =
 (* Construct an instance of Hhbc_options.t from the options passed in as well as
  * as specified in `-v str` on the command line.
  *)
-let get_options_from_config ?(init = default) ?(config_list = []) config_json =
-  extract_config_options_from_json ~init config_json
-  |> override_from_cli config_list
-
 let apply_config_overrides_statelessly config_list config_jsons =
   List.fold_right
     ~init:default

--- a/hphp/hack/test/rust/hhbc_options_migration_test.ml
+++ b/hphp/hack/test/rust/hhbc_options_migration_test.ml
@@ -154,7 +154,8 @@ let json_override_2bools =
 (* Sanity-check test data: if this fails other tests are meaningless *)
 let test_override_2bools_sanity_check _ =
   let opts =
-    Hhbc_options.get_options_from_config
+    Hhbc_options.extract_config_options_from_json
+      ~init:Hhbc_options.default
       (Some (Hh_json.json_of_string json_override_2bools))
   in
   assert_equal false Hhbc_options.(enable_coroutines opts);


### PR DESCRIPTION
Summary:
Instead of accumulating Hhbc_options into `pending_config` on the fly
just so that `log_extern_compiler_perf` is up to date,
lazily construct them when they are needed.
To avoid potentially constructing them twice when compiling or (fact-) parsing),
propagate those from these handlers & reuse in output handler
(which may read the options if daemon or dump if CLI mode).

*Motivation*:
This allows replacing calls to `apply_config_overrides_statelessly` via a Rust FFI, i.e.,
`Options_ffi.from_configs`, which in turn allows us to kill most of the code in `Hhbc_options.ml`.

Reviewed By: dabek

Differential Revision: D20212917

fbshipit-source-id: c2ab0947be56997833d16e60ccc0416ce963f459