### PR TITLE
Remote type check should not be enabled by default

### DIFF
--- a/hphp/hack/src/server/serverLocalConfig.ml
+++ b/hphp/hack/src/server/serverLocalConfig.ml
@@ -207,7 +207,7 @@ let default =
     prefetch_deferred_files = false;
     remote_type_check =
       {
-        enabled = true;
+        enabled = false;
         load_naming_table_on_full_init = false;
         max_batch_size = 8_000;
         min_batch_size = 5_000;


### PR DESCRIPTION
Summary: Shouldn't be enabled by default

Reviewed By: yinghuitan

Differential Revision: D20267036

fbshipit-source-id: 5c6ccaa6faf363b992932d647caf2327569e1fb7