### PR TITLE
remove polymorphic equality from src/utils

### DIFF
--- a/hphp/hack/src/utils/config_file/config_file_common.ml
+++ b/hphp/hack/src/utils/config_file/config_file_common.ml
@@ -7,7 +7,7 @@
  *
  *)
 
-open Core_kernel
+open Hh_prelude
 open Sys_utils
 
 type t = string SMap.t
@@ -45,7 +45,9 @@ let parse_contents (contents : string) : string SMap.t =
     ~f:
       begin
         fun acc line ->
-        if String.strip line = "" || (String.length line > 0 && line.[0] = '#')
+        if
+          String.(strip line = "")
+          || (String.length line > 0 && Char.equal line.[0] '#')
         then
           acc
         else
@@ -162,12 +164,12 @@ module Getters = struct
       List.exists
         ~f:(fun s ->
           let s =
-            if s = "master" then
+            if String.equal s "master" then
               ""
             else
               s
           in
-          s = Build_id.build_revision)
+          String.equal s Build_id.build_revision)
         x
 
   let bool_if_min_version key ?(prefix = None) ~default ~current_version config

--- a/hphp/hack/src/utils/core/telemetry.ml
+++ b/hphp/hack/src/utils/core/telemetry.ml
@@ -6,7 +6,7 @@
  *
  *)
 
-open Core_kernel
+open Hh_prelude
 
 type t = key_value_pair list
 
@@ -191,11 +191,11 @@ and diff_both
   | (JSON_Array _, _)
   | (_, JSON_Array _) ->
     acc_if all (key, val_c) acc
-  | (JSON_Bool val_c, JSON_Bool val_p) when val_c = val_p ->
+  | (JSON_Bool val_c, JSON_Bool val_p) when Bool.equal val_c val_p ->
     acc_if all (key, JSON_Bool val_c) acc
-  | (JSON_String val_c, JSON_String val_p) when val_c = val_p ->
+  | (JSON_String val_c, JSON_String val_p) when String.equal val_c val_p ->
     acc_if all (key, JSON_String val_c) acc
-  | (JSON_Number val_c, JSON_Number val_p) when val_c = val_p ->
+  | (JSON_Number val_c, JSON_Number val_p) when String.equal val_c val_p ->
     acc_if all (key, JSON_Number val_c) acc
   | (JSON_Null, JSON_Null) -> acc_if all (key, JSON_Null) acc
   | (JSON_Number c, JSON_Number p) ->

--- a/hphp/hack/src/utils/lwt_utils.ml
+++ b/hphp/hack/src/utils/lwt_utils.ml
@@ -1,4 +1,13 @@
-open Core_kernel
+(*
+ * Copyright (c) 2018, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the "hack" directory of this source tree.
+ *
+ *)
+
+open Hh_prelude
 
 let select
     (read_fds : Unix.file_descr list)
@@ -24,7 +33,7 @@ let select
       this list, so we could in theory just return any list (or not return any
       exceptional file descriptors at all). *)
       let exceptional_fds =
-        List.filter exn_fds ~f:(fun fd -> List.mem ~equal:( = ) fds fd)
+        List.filter exn_fds ~f:(fun fd -> List.mem ~equal:Poly.( = ) fds fd)
       in
       Lwt.return (Error exceptional_fds)
   in

--- a/hphp/hack/src/utils/multifile.ml
+++ b/hphp/hack/src/utils/multifile.ml
@@ -7,7 +7,7 @@
  *
  *)
 
-open Core_kernel
+open Hh_prelude
 
 (* This allows one to fake having multiple files in one file. This
  * is used only in unit test files.
@@ -33,7 +33,8 @@ let rec make_files = function
  *)
 let file_to_file_list file =
   let join_path p1 p2 =
-    if p1 <> "" && p2 <> "" then
+    let open Char in
+    if String.(p1 <> "" && p2 <> "") then
       if p1.[String.length p1 - 1] = '/' && p2.[0] = '/' then
         p1 ^ Str.string_after p2 1
       else if p1.[String.length p1 - 1] <> '/' && p2.[0] <> '/' then

--- a/hphp/hack/src/utils/php_escaping.ml
+++ b/hphp/hack/src/utils/php_escaping.ml
@@ -10,11 +10,13 @@
 (* Implementation of string escaping stuff. Ugggggggh.
  * See http://php.net/manual/en/language.types.string.php *)
 
-open Core_kernel
+open Hh_prelude
 
 let is_printable c = c >= ' ' && c <= '~'
 
-let is_lit_printable c = is_printable c && c <> '\\' && c <> '\"'
+let is_lit_printable c =
+  let open Char in
+  is_printable c && c <> '\\' && c <> '\"'
 
 let escape_char = function
   | '\n' -> "\\n"

--- a/hphp/hack/src/utils/pos_embedded.mli
+++ b/hphp/hack/src/utils/pos_embedded.mli
@@ -79,10 +79,10 @@ val exactly_matches_range :
   end_col:int ->
   bool
 
-val contains : 'a pos -> 'a pos -> bool
+val contains : t -> t -> bool
 
 (* Does first position strictly overlap the second position? *)
-val overlaps : 'a pos -> 'a pos -> bool
+val overlaps : t -> t -> bool
 
 val make : 'a -> b -> 'a pos
 

--- a/hphp/hack/src/utils/process/future.ml
+++ b/hphp/hack/src/utils/process/future.ml
@@ -14,7 +14,7 @@
  * A promise is a strongly-typed wrapper around Process
  *)
 
-open Core_kernel
+open Hh_prelude
 include Future_sig.Types
 
 type 'a delayed = {

--- a/hphp/hack/src/utils/process/process.ml
+++ b/hphp/hack/src/utils/process/process.ml
@@ -7,7 +7,7 @@
  *
  *)
 
-open Core_kernel
+open Hh_prelude
 open Ocaml_overrides
 open Stack_utils
 
@@ -189,7 +189,7 @@ let rec read_and_wait_pid ~(retries : int) (process : Process_types.t) :
     | Lifecycle_killed_due_to_overflow_stdin -> Error Overflow_stdin
     | Lifecycle_running { pid } ->
       let fds = List.rev_filter_map ~f:( ! ) [stdout_fd; stderr_fd] in
-      if fds = [] then
+      if List.is_empty fds then
         (* EOF reached for all FDs. Blocking wait. *)
         let (_, status) = Unix.waitpid [] pid in
         let () = lifecycle := Lifecycle_exited status in

--- a/hphp/hack/src/utils/relative_path.ml
+++ b/hphp/hack/src/utils/relative_path.ml
@@ -7,6 +7,7 @@
  *
  *)
 
+open Hh_prelude
 open Hh_core
 open Reordered_argument_collections
 open Utils
@@ -82,7 +83,7 @@ let default = (Dummy, "")
  * better on space usage. *)
 let storage_to_string (p, rest) = string_of_prefix p ^ "|" ^ rest
 
-let index_opt str ch = (try Some (String.index str ch) with Not_found -> None)
+let index_opt str ch = String.index str ch
 
 let storage_of_string str =
   match index_opt str '|' with
@@ -118,7 +119,7 @@ let to_tmp (_, rest) = (Tmp, rest)
 let to_root (_, rest) = (Root, rest)
 
 module Set = struct
-  include Reordered_argument_set (Set.Make (S))
+  include Reordered_argument_set (Caml.Set.Make (S))
 
   let pp fmt x =
     Format.fprintf fmt "@[<2>{";

--- a/hphp/hack/src/utils/sys/path.ml
+++ b/hphp/hack/src/utils/sys/path.ml
@@ -7,6 +7,7 @@
  *
  *)
 
+open Hh_prelude
 open Reordered_argument_collections
 include Sys
 
@@ -63,12 +64,12 @@ let parent path =
   else
     make (Filename.dirname path)
 
-let output = output_string
+let output = Stdlib.output_string
 
 let slash_escaped_string_of_path path =
   let buf = Buffer.create (String.length path) in
   String.iter
-    (fun ch ->
+    ~f:(fun ch ->
       match ch with
       | '\\' -> Buffer.add_string buf "zB"
       | ':' -> Buffer.add_string buf "zC"
@@ -87,7 +88,7 @@ let path_of_slash_escaped_string str =
       ()
     else
       let replacement =
-        if i < length - 1 && str.[i] = 'z' then
+        if i < length - 1 && Char.equal str.[i] 'z' then
           match str.[i + 1] with
           | 'B' -> Some '\\'
           | 'C' -> Some ':'
@@ -109,4 +110,4 @@ let path_of_slash_escaped_string str =
   consume 0;
   make (Buffer.contents buf)
 
-module Set = Reordered_argument_set (Set.Make (S))
+module Set = Reordered_argument_set (Caml.Set.Make (S))


### PR DESCRIPTION
Summary:
Remove usage of polymorphic equality in src/utils.

Note: in line_break_map.ml we use `Not_found`. If possible, we should
move to a more informative one, like `Not_found_s` or `raise_s`

Reviewed By: andrewjkennedy

Differential Revision: D20941710

fbshipit-source-id: 98fb077418510516a9aa917d317bffcfb6f87f61