### PR TITLE
Allow cow/escalation in ArrayData::renumber

### DIFF
--- a/hphp/runtime/base/array-common.cpp
+++ b/hphp/runtime/base/array-common.cpp
@@ -48,10 +48,11 @@ ArrayData* ArrayCommon::Dequeue(ArrayData* a, Variant &value) {
   if (!a->empty()) {
     auto const pos = a->iter_begin();
     value = a->getValue(pos);
-    auto const ret = a->remove(a->getKey(pos));
+    auto const result = a->remove(a->getKey(pos));
     // In PHP, array_shift() will cause all numerically key-ed values re-keyed
-    ret->renumber();
-    return ret;
+    auto const escalated = result->renumber();
+    if (escalated != result) decRefArr(result);
+    return escalated;
   }
   value = uninit_null();
   return a;

--- a/hphp/runtime/base/array-data-defs.h
+++ b/hphp/runtime/base/array-data-defs.h
@@ -277,7 +277,7 @@ inline void ArrayData::onSetEvalScalar() {
   return g_array_funcs.onSetEvalScalar[kind()](this);
 }
 
-inline void ArrayData::renumber() {
+inline ArrayData* ArrayData::renumber() {
   return g_array_funcs.renumber[kind()](this);
 }
 

--- a/hphp/runtime/base/array-data.cpp
+++ b/hphp/runtime/base/array-data.cpp
@@ -608,9 +608,10 @@ const ArrayFunctions g_array_funcs = {
   DISPATCH(Prepend)
 
   /*
-   * void Renumber(ArrayData*)
+   * ArrayData* Renumber(ArrayData*)
    *
-   *   Renumber integer keys on the array in place.
+   *   Renumber integer keys on the array. This method will operate in place
+   *   if possible, but it returns a new array if we need copy / escalation.
    */
   DISPATCH(Renumber)
 

--- a/hphp/runtime/base/array-data.h
+++ b/hphp/runtime/base/array-data.h
@@ -672,9 +672,10 @@ public:
   bool convertKey(const StringData* key, int64_t& i) const;
 
   /*
-   * Re-index all numeric keys to start from 0.
+   * Re-index all numeric keys to start from 0. This operation may require
+   * escalation on the array, so it returns the new result.
    */
-  void renumber();
+  ArrayData* renumber();
 
   /*
    * Get the string name for the array kind `kind'.
@@ -876,7 +877,7 @@ struct ArrayFunctions {
   ArrayData* (*pop[NK])(ArrayData*, Variant& value);
   ArrayData* (*dequeue[NK])(ArrayData*, Variant& value);
   ArrayData* (*prepend[NK])(ArrayData*, TypedValue v);
-  void (*renumber[NK])(ArrayData*);
+  ArrayData* (*renumber[NK])(ArrayData*);
   void (*onSetEvalScalar[NK])(ArrayData*);
   ArrayData* (*toPHPArray[NK])(ArrayData*, bool);
   ArrayData* (*toPHPArrayIntishCast[NK])(ArrayData*, bool);

--- a/hphp/runtime/base/empty-array.h
+++ b/hphp/runtime/base/empty-array.h
@@ -126,7 +126,7 @@ struct EmptyArray final : type_scan::MarkCollectable<EmptyArray> {
   static ArrayData* ToDict(ArrayData*, bool);
   static ArrayData* ToVec(ArrayData*, bool);
   static ArrayData* ToKeyset(ArrayData*, bool);
-  static void Renumber(ArrayData*) {}
+  static ArrayData* Renumber(ArrayData* ad) { return ad; }
   static void OnSetEvalScalar(ArrayData*);
 
 private:

--- a/hphp/runtime/base/mixed-array.cpp
+++ b/hphp/runtime/base/mixed-array.cpp
@@ -1751,8 +1751,10 @@ ArrayData* MixedArray::ToDictDict(ArrayData* ad, bool) {
   return ad;
 }
 
-void MixedArray::Renumber(ArrayData* ad) {
+ArrayData* MixedArray::Renumber(ArrayData* adIn) {
+  auto const ad = adIn->cowCheck() ? Copy(adIn) : adIn;
   asMixed(ad)->compact(true);
+  return ad;
 }
 
 void MixedArray::OnSetEvalScalar(ArrayData* ad) {

--- a/hphp/runtime/base/mixed-array.h
+++ b/hphp/runtime/base/mixed-array.h
@@ -358,7 +358,7 @@ public:
   static constexpr auto ToVArray = &ArrayCommon::ToVArray;
   static ArrayData* ToDArray(ArrayData*, bool);
 
-  static void Renumber(ArrayData*);
+  static ArrayData* Renumber(ArrayData*);
   static void OnSetEvalScalar(ArrayData*);
   static void Release(ArrayData*);
   // Recursively register {allocation, rootAPCHandle} with APCGCManager

--- a/hphp/runtime/base/packed-array.h
+++ b/hphp/runtime/base/packed-array.h
@@ -112,7 +112,7 @@ struct PackedArray final : type_scan::MarkCollectable<PackedArray> {
   static ArrayData* ToDArray(ArrayData*, bool);
   static ArrayData* ToDict(ArrayData*, bool);
   static ArrayData* ToVec(ArrayData*, bool);
-  static void Renumber(ArrayData*) {}
+  static ArrayData* Renumber(ArrayData* ad) { return ad; }
   static void OnSetEvalScalar(ArrayData*);
 
   static constexpr auto ToKeyset = &ArrayCommon::ToKeyset;

--- a/hphp/runtime/base/record-array.cpp
+++ b/hphp/runtime/base/record-array.cpp
@@ -492,7 +492,7 @@ ArrayData* RecordArray::Prepend(ArrayData* ad, TypedValue v) {
   );
 }
 
-void RecordArray::Renumber(ArrayData*) {
+ArrayData* RecordArray::Renumber(ArrayData*) {
   throw_not_supported("Renumber", "Record-array");
 }
 

--- a/hphp/runtime/base/record-array.h
+++ b/hphp/runtime/base/record-array.h
@@ -90,7 +90,7 @@ struct RecordArray : ArrayData,
   static ArrayData* Pop(ArrayData*, Variant& value);
   static ArrayData* Dequeue(ArrayData*, Variant& value);
   static ArrayData* Prepend(ArrayData*, TypedValue v);
-  static void Renumber(ArrayData*);
+  static ArrayData* Renumber(ArrayData*);
   static void OnSetEvalScalar(ArrayData*);
   static ArrayData* ToPHPArray(ArrayData*, bool);
   static constexpr auto ToPHPArrayIntishCast = &ToPHPArray;

--- a/hphp/runtime/base/set-array.cpp
+++ b/hphp/runtime/base/set-array.cpp
@@ -758,7 +758,7 @@ ArrayData* SetArray::Prepend(ArrayData* ad, TypedValue v) {
   return a;
 }
 
-void SetArray::Renumber(ArrayData*) {
+ArrayData* SetArray::Renumber(ArrayData*) {
   SystemLib::throwInvalidOperationExceptionObject(
     "Invalid keyset operation (renumbering)"
   );

--- a/hphp/runtime/base/set-array.h
+++ b/hphp/runtime/base/set-array.h
@@ -417,7 +417,7 @@ public:
   static ArrayData* Pop(ArrayData*, Variant&);
   static ArrayData* Dequeue(ArrayData*, Variant&);
   static ArrayData* Prepend(ArrayData*, TypedValue);
-  static void Renumber(ArrayData*);
+  static ArrayData* Renumber(ArrayData*);
   static void OnSetEvalScalar(ArrayData*);
   static constexpr auto ToDict = &ArrayCommon::ToDict;
   static constexpr auto ToVec = &ArrayCommon::ToVec;

--- a/hphp/runtime/base/type-array.cpp
+++ b/hphp/runtime/base/type-array.cpp
@@ -318,12 +318,8 @@ Array& Array::mergeImpl(ArrayData *data) {
   if (m_arr == nullptr || data == nullptr) {
     throw_bad_array_merge();
   }
-  if (!data->empty()) {
-    auto const escalated = m_arr->merge(data);
-    if (escalated != m_arr) m_arr = Ptr::attach(escalated);
-  } else {
-    m_arr->renumber();
-  }
+  auto const escalated = data->empty() ? m_arr->renumber() : m_arr->merge(data);
+  if (escalated != m_arr) m_arr = Ptr::attach(escalated);
   return *this;
 }
 

--- a/hphp/runtime/vm/globals-array.cpp
+++ b/hphp/runtime/vm/globals-array.cpp
@@ -268,7 +268,9 @@ ArrayData* GlobalsArray::CopyStatic(const ArrayData*) {
     "not implemented.");
 }
 
-void GlobalsArray::Renumber(ArrayData*) {}
+ArrayData* GlobalsArray::Renumber(ArrayData* ad) {
+  return ad;
+}
 
 void GlobalsArray::OnSetEvalScalar(ArrayData*) {
   not_reached();

--- a/hphp/runtime/vm/globals-array.h
+++ b/hphp/runtime/vm/globals-array.h
@@ -103,7 +103,7 @@ public:
   static ArrayData* CopyStatic(const ArrayData*);
   static constexpr auto Pop = &ArrayCommon::Pop;
   static constexpr auto Dequeue = &ArrayCommon::Dequeue;
-  static void Renumber(ArrayData*);
+  static ArrayData* Renumber(ArrayData*);
   static void OnSetEvalScalar(ArrayData*);
 
   static ArrayData* EscalateForSort(ArrayData*, SortFunction sf);


### PR DESCRIPTION
Summary:
All current ArrayKind implementations have the following property: the "renumber" operation can be performed on them without changing their layout.

We don't necessarily want to provide this property for bespoke array layouts, though. For example, we may have a record-like layout with integer keys; renumbering such a layout may require escalation to a MixedArray.

Update Renumber to allow for cow/escalation. There's actually a bug in the current implementation: we don't cow in MixedArray when we should. This bug is asymptomatic but only due to highly non-local invariants: the small handful of places that use Array::merge (which calls renumber) happen to provide it EITHER an empty array or an array with refcount 1. I hate having to do such a complex proof of correctness, so I just had MixedArray::Renumber do the cow check as well.

The other ArrayKind implementations never need to cow or escalate, because Renumber is trivial on them. (Preserving PHP behavior, it has no effect on the globals array.)

Reviewed By: ricklavoie

Differential Revision: D20952787

fbshipit-source-id: d69ca22e5a6531022e7ea2b848cd6a88136dc9bf