### PR TITLE
allow extensions to put serialized data in the profile dump

### DIFF
--- a/hphp/runtime/ext/extension-registry.h
+++ b/hphp/runtime/ext/extension-registry.h
@@ -6,7 +6,14 @@
 #include "hphp/runtime/base/type-string.h"
 #include "hphp/util/hdf.h"
 
-namespace HPHP { namespace ExtensionRegistry {
+namespace HPHP {
+
+namespace jit {
+struct ProfDataSerializer;
+struct ProfDataDeserializer;
+}
+
+namespace ExtensionRegistry {
 /////////////////////////////////////////////////////////////////////////////
 
 void registerExtension(Extension* ext);
@@ -36,7 +43,12 @@ void requestShutdown();
 
 bool modulesInitialised();
 
+void serialize(jit::ProfDataSerializer& ser);
+void deserialize(jit::ProfDataDeserializer& des);
+
 /////////////////////////////////////////////////////////////////////////////
-}} // namespace HPHP::ExtensionRegistry
+} // namespace HPHP::ExtensionRegistry
+
+}
 
 #endif // incl_HPHP_EXTENSION_REGISTRY_H

--- a/hphp/runtime/ext/extension.h
+++ b/hphp/runtime/ext/extension.h
@@ -86,6 +86,13 @@ public:
   // override this to control extension_loaded() return value
   virtual bool moduleEnabled() const;
 
+  // override these functions to perform extension-specific jumpstart,
+  // leveraging the JIT profile data serialization mechanisms.
+  virtual std::string serialize() { return {}; }
+  // throws std::runtime_error to abort the whole thing if needed. The extension
+  // can also choose to swallow the error.
+  virtual void deserialize(std::string) {}
+
   using DependencySet = std::set<std::string>;
   using DependencySetMap = std::map<Extension*, DependencySet>;
 

--- a/hphp/runtime/vm/jit/prof-data-serialize.cpp
+++ b/hphp/runtime/vm/jit/prof-data-serialize.cpp
@@ -25,6 +25,7 @@
 #include "hphp/runtime/base/variable-serializer.h"
 #include "hphp/runtime/base/vm-worker.h"
 
+#include "hphp/runtime/ext/extension-registry.h"
 #include "hphp/runtime/ext/std/ext_std_closure.h"
 
 #include "hphp/runtime/vm/class.h"
@@ -1550,6 +1551,7 @@ std::string serializeProfData(const std::string& filename) {
     };
 
     write_units_preload(ser);
+    ExtensionRegistry::serialize(ser);
     PropertyProfile::serialize(ser);
     InstanceBits::init();
     InstanceBits::serialize(ser);
@@ -1640,6 +1642,7 @@ std::string deserializeProfData(const std::string& filename, int numWorkers) {
     }
 
     read_units_preload(ser);
+    ExtensionRegistry::deserialize(ser);
     PropertyProfile::deserialize(ser);
     InstanceBits::deserialize(ser);
     read_global_array_map(ser);

--- a/hphp/runtime/vm/jit/prof-data-serialize.h
+++ b/hphp/runtime/vm/jit/prof-data-serialize.h
@@ -150,6 +150,9 @@ struct ProfDataDeserializer {
   friend std::string deserializeProfData(const std::string&, int);
 };
 
+void write_raw(ProfDataSerializer& ser, const void* data, size_t sz);
+void read_raw(ProfDataDeserializer& ser, void* data, size_t sz);
+
 template<class T>
 void write_raw(ProfDataSerializer& ser, const T& t) {
   write_raw(ser, &t, sizeof(t));


### PR DESCRIPTION
Summary: This mechanism allows each extension to perform appropriate initialization actions when deserializing profile data.

Reviewed By: ottoni

Differential Revision: D21346064

fbshipit-source-id: 07000b0cc4a2cbfb11eb2f349d2aa333c7c9c2f1