### PR TITLE
Fake members are not invaliated on assignment to locals

### DIFF
--- a/hphp/hack/src/decl/decl_pos_utils.ml
+++ b/hphp/hack/src/decl/decl_pos_utils.ml
@@ -56,7 +56,8 @@ struct
     | Ryield_asyncgen p -> Ryield_asyncgen (pos p)
     | Ryield_asyncnull p -> Ryield_asyncnull (pos p)
     | Ryield_send p -> Ryield_send (pos p)
-    | Rlost_info (s, r1, p2, l) -> Rlost_info (s, reason r1, pos p2, l)
+    | Rlost_info (s, r1, Blame (p2, l)) ->
+      Rlost_info (s, reason r1, Blame (pos p2, l))
     | Rformat (p1, s, r) -> Rformat (pos p1, s, reason r)
     | Rclass_class (p, s) -> Rclass_class (pos p, s)
     | Runknown_class p -> Runknown_class (pos p)

--- a/hphp/hack/src/typing/typing_env.mli
+++ b/hphp/hack/src/typing/typing_env.mli
@@ -168,7 +168,9 @@ val get_allow_solve_globals : env -> bool
 
 val set_allow_solve_globals : env -> bool -> env
 
-val forget_members : env -> Typing_fake_members.blame -> env
+val forget_members : env -> Reason.blame -> env
+
+val forget_prefixed_members : env -> Local_id.t -> Reason.blame -> env
 
 val get_fake_members : env -> Typing_fake_members.t
 
@@ -185,9 +187,9 @@ module FakeMembers : sig
   val check_instance_invalid :
     env -> Nast.expr -> string -> locl_ty -> env * locl_ty
 
-  val make : env -> Nast.expr -> string -> env * Local_id.t
+  val make : env -> Nast.expr -> string -> Pos.t -> env * Local_id.t
 
-  val make_static : env -> Nast.class_id_ -> string -> env * Local_id.t
+  val make_static : env -> Nast.class_id_ -> string -> Pos.t -> env * Local_id.t
 end
 
 val tany : env -> locl_phase ty_

--- a/hphp/hack/src/typing/typing_fake_members.ml
+++ b/hphp/hack/src/typing/typing_fake_members.ml
@@ -7,126 +7,167 @@
  *
  *)
 
-(* Validation blame: call or lambda *)
-type blame =
-  | Blame_call of Pos.t
-  | Blame_lambda of Pos.t
+open Hh_prelude
+module Reason = Typing_reason
+
+module S = struct
+  type t = Local_id.t * Reason.blame
+
+  let compare (lid1, _) (lid2, _) = compare lid1 lid2
+end
+
+(* A set that treats blame as metadata *)
+module BlameSet = struct
+  include Caml.Set.Make (S)
+
+  let find_by_lid_opt lid blame_set =
+    filter (fun (lid', _) -> Local_id.equal lid lid') blame_set |> choose_opt
+
+  let member_by_lid lid blame_set =
+    exists (fun (lid', _) -> Local_id.equal lid lid') blame_set
+
+  let attach_blame blame blame_set =
+    map (fun (lid, _) -> (lid, blame)) blame_set
+end
 
 (* Fake member validation.
  *   Valid valid
  * means that identifiers in [valid] are valid fake members
- *   Invalidated { valid, invalid, blame }
+ *   Invalidated { valid, invalid }
  * means that identifiers in [invalid] have been invalidated
- * by the call or lambda described by [blame], but [valid]
- * are more recent valid fake members. For example
+ * by a call, lambda, or assignment described by the blame attached to
+ * the element, but [valid] are more recent valid fake members. For example
  *
  *   // Valid []
- *   if ($x::f !== null) {
- *     // Valid ["$x::f"]
+ *   if ($x::f !== null) { // P0
+ *     // Valid [("$x::f", Blame_out_of_scope P0)]
  *     foo(); // P1
- *     // Invalidated { valid = []; invalid = ["$x::f"]; blame = Blame_call P1 }
- *     if ($y::g !== null) {
- *       // Invalidated { valid = ["$y::g"]; invalid = ["$x::f"]; blame = Blame_call P1 }
- *       $f = () ==>  // P2
- *       // Invalidated { valid = []; invalid = ["$x::f"; "$y::g"]; blame = Blame_lambda P2 }
+ *     // Invalidated { valid = []; invalid = [("$x::f", Blame_call P1)] }
+ *     if ($y::g !== null) { // P2
+ *       // Invalidated { valid = [("$y::g", Blame_out_of_scope P2)]; invalid = [("$x::f", Blame_call P1)] }
+ *       $f = () ==>  // P3
+ *       // Invalidated { valid = []; invalid = [("$x::f", Blame_lambda P3); ("$y::g", Blame_lambda P2)] }
          ...
  *)
 type t =
-  | Valid of Local_id.Set.t
+  | Valid of BlameSet.t
   | Invalidated of {
-      valid: Local_id.Set.t;
-      (* Non-empty and disjoint from valid *)
-      invalid: Local_id.Set.t;
-      (* cause of invalidation: call or lambda *)
-      blame: blame;
+      valid: BlameSet.t;
+      (* Non-empty and disjoint from valid. *)
+      invalid: BlameSet.t;
     }
 
-let empty = Valid Local_id.Set.empty
+let empty = Valid BlameSet.empty
 
 (* Combine validation information at a join point *)
 let join fake1 fake2 =
   match (fake1, fake2) with
-  | (Valid ids1, Valid ids2) -> Valid (Local_id.Set.inter ids1 ids2)
-  | (Invalidated { valid = v2; invalid; blame }, Valid v1)
-  | (Valid v1, Invalidated { valid = v2; invalid; blame }) ->
-    let valid = Local_id.Set.inter v1 v2 in
-    let invalid = Local_id.Set.union invalid (Local_id.Set.diff v2 valid) in
-    Invalidated { valid; invalid; blame }
-  | ( Invalidated { valid = v1; invalid = i1; blame },
-      Invalidated { valid = v2; invalid = i2; _ } ) ->
-    Invalidated
-      {
-        valid = Local_id.Set.inter v1 v2;
-        invalid = Local_id.Set.union i1 i2;
-        blame;
-      }
+  | (Valid ids1, Valid ids2) -> Valid (BlameSet.inter ids1 ids2)
+  | (Invalidated { valid = v2; invalid }, Valid v1)
+  | (Valid v1, Invalidated { valid = v2; invalid }) ->
+    let valid = BlameSet.inter v1 v2 in
+    let invalid = BlameSet.union invalid (BlameSet.diff v2 valid) in
+    Invalidated { valid; invalid }
+  | ( Invalidated { valid = v1; invalid = i1 },
+      Invalidated { valid = v2; invalid = i2 } ) ->
+    Invalidated { valid = BlameSet.inter v1 v2; invalid = BlameSet.union i1 i2 }
 
 (* Does fake1 entail fake2? *)
 let sub fake1 fake2 =
   match (fake1, fake2) with
-  | (Valid ids1, Valid ids2) -> Local_id.Set.subset ids2 ids1
+  | (Valid ids1, Valid ids2) -> BlameSet.subset ids2 ids1
   | (Invalidated { valid = v2; invalid; _ }, Valid v1) ->
-    Local_id.Set.subset v1 v2
-    && Local_id.Set.is_empty (Local_id.Set.diff invalid v2)
-  | (Valid v1, Invalidated { valid = v2; _ }) -> Local_id.Set.subset v2 v1
+    BlameSet.subset v1 v2 && BlameSet.is_empty (BlameSet.diff invalid v2)
+  | (Valid v1, Invalidated { valid = v2; _ }) -> BlameSet.subset v2 v1
   | ( Invalidated { valid = v1; invalid = i1; _ },
       Invalidated { valid = v2; invalid = i2; _ } ) ->
-    Local_id.Set.subset v2 v1 && Local_id.Set.subset i1 i2
+    BlameSet.subset v2 v1 && BlameSet.subset i1 i2
 
 let is_valid fake lid =
   match fake with
   | Invalidated { valid; _ }
   | Valid valid ->
-    Local_id.Set.mem lid valid
+    BlameSet.member_by_lid lid valid
 
 let is_invalid fake lid =
   match fake with
-  | Invalidated { invalid; blame; _ } ->
-    if Local_id.Set.mem lid invalid then
-      Some blame
-    else
-      None
+  | Invalidated { invalid; _ } ->
+    Option.map (BlameSet.find_by_lid_opt lid invalid) snd
   | Valid _ -> None
 
 let forget fake blame =
   match fake with
-  | Valid valid when Local_id.Set.is_empty valid -> fake
+  | Valid valid when BlameSet.is_empty valid -> fake
   | Valid valid ->
-    Invalidated { valid = Local_id.Set.empty; invalid = valid; blame }
+    Invalidated
+      { valid = BlameSet.empty; invalid = BlameSet.attach_blame blame valid }
   | Invalidated { valid; invalid; _ } ->
     Invalidated
       {
-        valid = Local_id.Set.empty;
-        invalid = Local_id.Set.union valid invalid;
-        blame;
+        valid = BlameSet.empty;
+        invalid = BlameSet.attach_blame blame (BlameSet.union valid invalid);
       }
 
-let add fake lid =
-  match fake with
-  | Valid valid -> Valid (Local_id.Set.add lid valid)
-  | Invalidated ({ valid; _ } as info) ->
-    Invalidated { info with valid = Local_id.Set.add lid valid }
+let forget_prefixed (fake_members : t) prefix_lid blame : t =
+  let is_prefixed (fake_id, _blame) =
+    String.is_prefix
+      ~prefix:(Local_id.to_string prefix_lid ^ "->")
+      (Local_id.to_string fake_id)
+  in
+  let invalidate_prefixed valid =
+    let (prefixed, others) = BlameSet.partition is_prefixed valid in
+    (BlameSet.attach_blame blame prefixed, others)
+  in
+  match fake_members with
+  | Valid valid when BlameSet.is_empty valid -> fake_members
+  | Valid valid ->
+    let (invalid, valid) = invalidate_prefixed valid in
+    Invalidated { valid; invalid }
+  | Invalidated { valid; invalid } ->
+    let (invalidated, valid) = invalidate_prefixed valid in
+    Invalidated { valid; invalid = BlameSet.union invalidated invalid }
 
-let blame_as_log_value blame =
-  match blame with
-  | Blame_call p -> Typing_log_value.(make_map [("Blame_call", pos_as_value p)])
-  | Blame_lambda p ->
-    Typing_log_value.(make_map [("Blame_lambda", pos_as_value p)])
-
-let as_log_value fake =
+let add fake lid pos =
   match fake with
   | Valid valid ->
-    Typing_log_value.(make_map [("Valid", local_id_set_as_value valid)])
-  | Invalidated { valid; invalid; blame } ->
+    Valid (BlameSet.add (lid, Reason.(Blame (pos, BSout_of_scope))) valid)
+  | Invalidated ({ valid; _ } as info) ->
+    Invalidated
+      {
+        info with
+        valid = BlameSet.add (lid, Reason.(Blame (pos, BSout_of_scope))) valid;
+      }
+
+let blame_as_log_value (Reason.Blame (p, blame_source)) =
+  match blame_source with
+  | Reason.BScall ->
+    Typing_log_value.(make_map [("Blame_call", pos_as_value p)])
+  | Reason.BSlambda ->
+    Typing_log_value.(make_map [("Blame_lambda", pos_as_value p)])
+  | Reason.BSassignment ->
+    Typing_log_value.(make_map [("Blame_assigment", pos_as_value p)])
+  | Reason.BSout_of_scope ->
+    Typing_log_value.(make_map [("Blame_out_of_scope", pos_as_value p)])
+
+let as_log_value fake =
+  let log_blame_set_as_value set =
+    Typing_log_value.make_map
+      (List.map (BlameSet.elements set) (fun (lid, blame_opt) ->
+           ( Typing_log_value.local_id_as_string lid,
+             blame_as_log_value blame_opt )))
+  in
+  match fake with
+  | Valid valid ->
+    Typing_log_value.(make_map [("Valid", log_blame_set_as_value valid)])
+  | Invalidated { valid; invalid } ->
     Typing_log_value.(
       make_map
         [
           ( "Invalidated",
             make_map
               [
-                ("valid", local_id_set_as_value valid);
-                ("invalid", local_id_set_as_value invalid);
-                ("blame", blame_as_log_value blame);
+                ("valid", log_blame_set_as_value valid);
+                ("invalid", log_blame_set_as_value invalid);
               ] );
         ])
 

--- a/hphp/hack/src/typing/typing_fake_members.mli
+++ b/hphp/hack/src/typing/typing_fake_members.mli
@@ -7,13 +7,10 @@
  *
  *)
 
+module Reason = Typing_reason
+
 (* Validation information for fake members *)
 type t
-
-(* Validation blame: call or lambda *)
-type blame =
-  | Blame_call of Pos.t
-  | Blame_lambda of Pos.t
 
 (* Initial validation *)
 val empty : t
@@ -31,15 +28,19 @@ val join : t -> t -> t
 val is_valid : t -> Local_id.t -> bool
 
 (* Has this identifier been invalidated? If so, return position of
- * call or lambda that is responsible *)
-val is_invalid : t -> Local_id.t -> blame option
+ * the event that is responsible *)
+val is_invalid : t -> Local_id.t -> Reason.blame option
 
-(* Invalidate all fake members, and remember the position of the call
- * or lambda that is responsible *)
-val forget : t -> blame -> t
+(* Invalidate all fake members, and remember the position of the event
+ * that is responsible *)
+val forget : t -> Reason.blame -> t
+
+(* Invalidate fake members that are prefixed by some identifier, and remember
+ * the position of the assignment that is responsible *)
+val forget_prefixed : t -> Local_id.t -> Reason.blame -> t
 
 (* Add a valid fake member access *)
-val add : t -> Local_id.t -> t
+val add : t -> Local_id.t -> Pos.t -> t
 
 (* Convert to a value for logging *)
 val as_log_value : t -> Typing_log_value.value

--- a/hphp/hack/test/typecheck/refinements/out_of_scope.php
+++ b/hphp/hack/test/typecheck/refinements/out_of_scope.php
@@ -1,0 +1,18 @@
+<?hh // strict
+
+class C {
+  public ?int $i;
+  public ?int $j;
+}
+
+function foo(): void {}
+
+function testit(C $c): int {
+  if (1 == 2) {
+    assert($c->j is nonnull);
+    foo();
+    assert($c->i is nonnull);
+  }
+
+  return $c->i;
+}

--- a/hphp/hack/test/typecheck/refinements/out_of_scope.php.exp
+++ b/hphp/hack/test/typecheck/refinements/out_of_scope.php.exp
@@ -1,0 +1,9 @@
+File "out_of_scope.php", line 17, characters 10-14:
+Invalid return type (Typing[4110])
+File "out_of_scope.php", line 10, characters 24-26:
+Expected int
+File "out_of_scope.php", line 4, characters 10-13:
+But got ?int
+File "out_of_scope.php", line 14, characters 12-16:
+All the local information about $c->i has been invalidated because of scope change.
+This is a limitation of the type-checker, use a local if that's the problem.

--- a/hphp/hack/test/typecheck/refinements/uninvalidated_fake_member.php
+++ b/hphp/hack/test/typecheck/refinements/uninvalidated_fake_member.php
@@ -1,0 +1,17 @@
+<?hh // strict
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+class Fooish {
+  public function foo():void { }
+}
+class C {
+  public function __construct(public mixed $m) { }
+}
+function testit():void {
+  $cfooish = new C(new Fooish());
+  $cstring = new C("a");
+  if ($cfooish->m is Fooish) {
+    $cfooish = $cstring;
+    $cfooish->m->foo();
+  }
+}

--- a/hphp/hack/test/typecheck/refinements/uninvalidated_fake_member.php.exp
+++ b/hphp/hack/test/typecheck/refinements/uninvalidated_fake_member.php.exp
@@ -1,0 +1,4 @@
+File "uninvalidated_fake_member.php", line 15, characters 18-20:
+You are trying to access the method 'foo' but this is a mixed value. Use a specific class or interface name. (Typing[4064])
+File "uninvalidated_fake_member.php", line 8, characters 38-42:
+Definition is here

--- a/hphp/hack/test/typecheck/refinements/uninvalidated_fake_member2.php
+++ b/hphp/hack/test/typecheck/refinements/uninvalidated_fake_member2.php
@@ -1,0 +1,18 @@
+<?hh // strict
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+class D {
+  public function foo(): void { }
+}
+class C {
+  public ?D $d;
+  public function __construct() { }
+}
+function testit():void {
+  $c1 = new C();
+  $c2 = new C();
+  if ($c1->d is nonnull) {
+    $c1 = $c2;
+    $c1->d->foo();
+  }
+}

--- a/hphp/hack/test/typecheck/refinements/uninvalidated_fake_member2.php.exp
+++ b/hphp/hack/test/typecheck/refinements/uninvalidated_fake_member2.php.exp
@@ -1,0 +1,7 @@
+File "uninvalidated_fake_member2.php", line 16, characters 13-15:
+You are trying to access the method 'foo' but this object can be null. (Typing[4064])
+File "uninvalidated_fake_member2.php", line 8, characters 10-11:
+This can be null
+File "uninvalidated_fake_member2.php", line 15, characters 5-13:
+All the local information about $c1->d has been invalidated by this assignment.
+This is a limitation of the type-checker, use a local if that's the problem.

--- a/hphp/hack/test/typecheck/refinements/uninvalidated_fake_member3.php
+++ b/hphp/hack/test/typecheck/refinements/uninvalidated_fake_member3.php
@@ -1,0 +1,23 @@
+<?hh // strict
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+class D {
+  public int $foo = 42;
+}
+class C {
+  public ?D $d;
+  public function __construct() { }
+}
+function bar(): void { }
+
+function testit():void {
+  $c1 = new C();
+  $c2 = new C();
+  $c3 = new C();
+  if ($c1->d is nonnull) {
+    bar();
+    $c2 = $c3;
+    // The following should fail because of bar()
+    $c1->d->foo;
+  }
+}

--- a/hphp/hack/test/typecheck/refinements/uninvalidated_fake_member3.php.exp
+++ b/hphp/hack/test/typecheck/refinements/uninvalidated_fake_member3.php.exp
@@ -1,0 +1,7 @@
+File "uninvalidated_fake_member3.php", line 21, characters 13-15:
+You are trying to access the property 'foo' but this object can be null. (Typing[4064])
+File "uninvalidated_fake_member3.php", line 8, characters 10-11:
+This can be null
+File "uninvalidated_fake_member3.php", line 18, characters 5-9:
+All the local information about $c1->d has been invalidated during this call.
+This is a limitation of the type-checker, use a local if that's the problem.


### PR DESCRIPTION
Summary:
- Fake members can now be invalidated by an assignment which causes all fake members based on the LHS of the assignment to be invalid.
- Fake member invalidation now keeps track of a blame per invalid fake member, rather than one blame for all invalidations to enable error localisation
- We now have a blame for refinements going out of scope

Reviewed By: CatherineGasnier

Differential Revision: D21526712

fbshipit-source-id: c6218b7ba621d2705bfe79726f425b055d935d9c