### PR TITLE
Implement getBaseTypes and getDerivedTypes

### DIFF
--- a/hphp/runtime/base/autoload-map.h
+++ b/hphp/runtime/base/autoload-map.h
@@ -134,4 +134,22 @@ struct AutoloadMap {
                                const Variant& err) const = 0;
 };
 
+/**
+ * An AutoloadMap which can also return data not directly related to
+ * autoloading.
+ */
+struct Facts : public AutoloadMap {
+  virtual ~Facts() = default;
+
+  /**
+   * Return all types in the repo which the given type extends.
+   */
+  virtual Array getBaseTypes(const String& derivedType) = 0;
+
+  /**
+   * Return all types in the repo which extend the given type.
+   */
+  virtual Array getDerivedTypes(const String& baseType) = 0;
+};
+
 } // namespace HPHP


### PR DESCRIPTION
Summary:
We're moving on from natively autoloading code to natively answering Facts queries. Facts queries are queries about the entire repo, like queries about all the classes which extend `WWWTest` and are tagged with a given `<<Oncall>>` attribute. For now, I'm going to expose two functions, `getBaseTypes()` and `getDerivedTypes()`, which allow you to see which types directly inherit from each other.

This diff adds the interface and exposes implementations for that interface in `WatchmanAutoloadMap` and `TrustedAutoloadMap`. I'll expose these functions to userland and test them in a followup diff.

Reviewed By: dneiter

Differential Revision: D21753626

fbshipit-source-id: dd309c52fd88d659d7ac295167c0ea4b155d0b56