### PR TITLE
move lpc and gpc to mutable env

### DIFF
--- a/hphp/hack/src/ifc/ifc_env.ml
+++ b/hphp/hack/src/ifc/ifc_env.ml
@@ -36,19 +36,18 @@ let new_proto_renv saved_tenv scope decl_env =
     pre_tenv = saved_tenv;
   }
 
-let new_renv proto_renv global_pc this_ty ret_ty =
+let new_renv proto_renv this_ty ret_ty =
+  { re_proto = proto_renv; re_this = this_ty; re_ret = ret_ty }
+
+let empty_lenv global_pc =
+  { le_vars = LMap.empty; le_gpc = [global_pc]; le_lpc = [] }
+
+let new_env global_pc =
   {
-    re_proto = proto_renv;
-    re_lpc = [];
-    re_gpc = [global_pc];
-    re_this = this_ty;
-    re_ret = ret_ty;
+    e_cont = KMap.singleton K.Next (empty_lenv global_pc);
+    e_acc = [];
+    e_deps = SSet.empty;
   }
-
-let empty_lenv = { le_vars = LMap.empty }
-
-let new_env =
-  { e_cont = KMap.singleton K.Next empty_lenv; e_acc = []; e_deps = SSet.empty }
 
 let acc env update = { env with e_acc = update env.e_acc }
 
@@ -65,7 +64,9 @@ let merge_lenv ~union env lenv1 lenv2 =
   let (env, le_vars) =
     LMap.merge_env env lenv1.le_vars lenv2.le_vars ~combine
   in
-  (env, { le_vars })
+  let le_gpc = lenv1.le_gpc @ lenv2.le_gpc in
+  let le_lpc = lenv1.le_lpc @ lenv2.le_lpc in
+  (env, { le_vars; le_gpc; le_lpc })
 
 (* Merge continuation envs, if a continuation is assigned a
    local env only in one of the arguments it will be kept as
@@ -78,8 +79,8 @@ let merge_and_set_cenv ~union env cenv1 cenv2 =
 
 let get_lenv_opt env k = KMap.find_opt k (get_cenv env)
 
-let lenv_set_local_type { le_vars } lid pty =
-  { le_vars = LMap.add lid pty le_vars }
+let lenv_set_local_type lenv lid pty =
+  { lenv with le_vars = LMap.add lid pty lenv.le_vars }
 
 let set_cont env k lenv = set_cenv env (KMap.add k lenv (get_cenv env))
 
@@ -94,3 +95,27 @@ let get_local_type env lid =
   match get_lenv_opt env K.Next with
   | None -> Tunion []
   | Some lenv -> LMap.find lid lenv.le_vars
+
+let get_gpc_policy env k =
+  match get_lenv_opt env k with
+  | None -> []
+  | Some lenv -> lenv.le_gpc
+
+let get_lpc_policy env k =
+  match get_lenv_opt env k with
+  | None -> []
+  | Some lenv -> lenv.le_lpc
+
+let push_pc env k pc =
+  match get_lenv_opt env k with
+  | None -> env
+  | Some lenv ->
+    let lenv =
+      { lenv with le_gpc = pc :: lenv.le_gpc; le_lpc = pc :: lenv.le_lpc }
+    in
+    set_cont env k lenv
+
+let set_pcs env k gpc lpc =
+  match get_lenv_opt env k with
+  | None -> env
+  | Some lenv -> set_cont env k { lenv with le_gpc = gpc; le_lpc = lpc }

--- a/hphp/hack/src/ifc/ifc_pretty.ml
+++ b/hphp/hack/src/ifc/ifc_pretty.ml
@@ -131,7 +131,16 @@ let prop =
   (fun fmt c -> aux 0 fmt (conjuncts c))
 
 let locals fmt env =
-  let pp_lenv fmt { le_vars } = LMap.make_pp Local_id.pp ptype fmt le_vars in
+  let pp_lenv fmt lenv =
+    pp_open_vbox fmt 0;
+    fprintf
+      fmt
+      "@[<hov2>lvars:@ %a@]"
+      (LMap.make_pp Local_id.pp ptype)
+      lenv.le_vars;
+    fprintf fmt "@,@[<hov2>pc: @[<hov>%a@]@]" policy (List.last_exn lenv.le_gpc);
+    pp_close_box fmt ()
+  in
   let pp_lenv_opt fmt = function
     | Some lenv -> pp_lenv fmt lenv
     | None -> fprintf fmt "<empty>"
@@ -140,15 +149,14 @@ let locals fmt env =
 
 let renv fmt renv =
   pp_open_vbox fmt 0;
-  fprintf fmt "* @[<hov2>pc: @[<hov>%a@]@]" policy (List.last_exn renv.re_gpc);
-  fprintf fmt "@,* @[<hov2>This:@ @[<hov>%a@]@]" (option ptype) renv.re_this;
+  fprintf fmt "* @[<hov2>This:@ @[<hov>%a@]@]" (option ptype) renv.re_this;
   fprintf fmt "@,* @[<hov2>Return:@ @[<hov>%a@]@]" ptype renv.re_ret;
   pp_close_box fmt ()
 
 let env fmt env =
   pp_open_vbox fmt 0;
   fprintf fmt "@[<hov2>Deps:@ %a@]" SSet.pp env.e_deps;
-  fprintf fmt "@,@[<hov2>Locals:@ %a@]" locals env;
+  fprintf fmt "@,Locals:@,  %a@." locals env;
   let p = Logic.conjoin env.e_acc in
   fprintf fmt "@,Constraints:@,  @[<v>%a@]" prop p;
   pp_close_box fmt ()

--- a/hphp/hack/src/ifc/ifc_types.ml
+++ b/hphp/hack/src/ifc/ifc_types.ml
@@ -88,7 +88,17 @@ module FlowSet = Set.Make (Flow)
 
 type security_lattice = FlowSet.t
 
-type local_env = { le_vars: ptype LMap.t }
+type local_env = {
+  le_vars: ptype LMap.t;
+  (* Policy tracking local effects, these effects
+     are not observable outside the current function.
+     Assignments to local variables fall into this
+     category. *)
+  le_lpc: policy list;
+  (* Policy tracking effects with global visibility,
+     like assignments to fields of an argument. *)
+  le_gpc: policy list;
+}
 
 (* The environment is mutable data that
    has to be threaded through *)
@@ -146,14 +156,6 @@ type proto_renv = {
 type renv = {
   (* Section of renv needed to initialize full renv *)
   re_proto: proto_renv;
-  (* Policy tracking local effects, these effects
-     are not observable outside the current function.
-     Assignments to local variables fall into this
-     category. *)
-  re_lpc: policy list;
-  (* Policy tracking effects with global visibility,
-     like assignments to fields of an argument. *)
-  re_gpc: policy list;
   (* Policy type of $this. *)
   re_this: ptype option;
   (* Return type of the function being checked. *)

--- a/hphp/hack/test/ifc/analysis/basics.php.exp
+++ b/hphp/hack/test/ifc/analysis/basics.php.exp
@@ -6,49 +6,61 @@ Decls:
   function \condition: { kind = public }
   
 Analyzing \binop:
-* pc: pc
 * This: None
 * Return: <ret>
-* Params: { $x -> <$x>; $y -> <$y> }
+* Params:
+  lvars: { $x -> <$x>; $y -> <$y> }
+  pc: pc
 * Final environment:
   Deps: {}
-  Locals: { $x -> <$x>; $y -> <$y> }
-  Constraints:
-    $x < ret
+  Locals:
+    lvars: { $x -> <$x>; $y -> <$y> }
+    pc: pc
+Constraints:
+  $x < ret
 
 Analyzing \assign0:
-* pc: pc
 * This: None
 * Return: <ret>
-* Params: { $arg -> <$arg> }
+* Params:
+  lvars: { $arg -> <$arg> }
+  pc: pc
 * Final environment:
   Deps: {}
-  Locals: { $arg -> <$arg>; $x -> <$x'1> }
-  Constraints:
-    [$arg < $x, PUBLIC < $x'1, $x'1 < ret]
+  Locals:
+    lvars: { $arg -> <$arg>; $x -> <$x'1> }
+    pc: pc
+Constraints:
+  [$arg < $x, PUBLIC < $x'1, $x'1 < ret]
 
 Analyzing \assign1:
-* pc: pc
 * This: None
 * Return: <ret>
-* Params: { $arg -> <$arg> }
+* Params:
+  lvars: { $arg -> <$arg> }
+  pc: pc
 * Final environment:
   Deps: {}
-  Locals: { $arg -> <$arg>; $x -> <$x'1> }
-  Constraints:
-    [$arg < $x, $x < $x'1, $x'1 < ret]
+  Locals:
+    lvars: { $arg -> <$arg>; $x -> <$x'1> }
+    pc: pc
+Constraints:
+  [$arg < $x, $x < $x'1, $x'1 < ret]
 
 Analyzing \condition:
-* pc: pc
 * This: None
 * Return: <ret>
-* Params: { $a0 -> <$a0>; $a1 -> <$a1>; $a2 -> <$a2> }
+* Params:
+  lvars: { $a0 -> <$a0>; $a1 -> <$a1>; $a2 -> <$a2> }
+  pc: pc
 * Final environment:
   Deps: {}
-  Locals: { $a0 -> <$a0>; $a1 -> <$a1>; $a2 -> <$a2>; $x -> <$x'2> }
-  Constraints:
-    [$a0 < $x, $a2 < $x, $a1 < $x'1, $a2 < $x'1, $x < $x'2, $x'1 < $x'2,
-     $x'2 < ret]
+  Locals:
+    lvars: { $a0 -> <$a0>; $a1 -> <$a1>; $a2 -> <$a2>; $x -> <$x'2> }
+    pc: pc
+Constraints:
+  [$a0 < $x, $a2 < $x, $a1 < $x'1, $a2 < $x'1, $x < $x'2, $x'1 < $x'2,
+   $x'2 < ret]
 
 Flow constraints for \assign0:
   

--- a/hphp/hack/test/ifc/analysis/calls_basics.php.exp
+++ b/hphp/hack/test/ifc/analysis/calls_basics.php.exp
@@ -11,102 +11,126 @@ Decls:
   function \indirect_flow_a_to_b_bis: { kind = public }
   
 Analyzing setb:
-* pc: pc
 * This: \C<\C, lump, a=?thunk, b=<B>>
 * Return: <ret>
-* Params: { $n -> <$n> }
+* Params:
+  lvars: { $n -> <$n> }
+  pc: pc
 * Final environment:
   Deps: {}
-  Locals: { $n -> <$n> }
-  Constraints:
-    [\C < B, $n < B, pc < B]
+  Locals:
+    lvars: { $n -> <$n> }
+    pc: pc
+Constraints:
+  [\C < B, $n < B, pc < B]
 
 Analyzing is_a_pos:
-* pc: pc
 * This: \C<\C, lump, a=<A>, b=?thunk>
 * Return: <ret>
-* Params: {}
+* Params:
+  lvars: {}
+  pc: pc
 * Final environment:
   Deps: {}
-  Locals: {}
-  Constraints:
-    [A < .a, \C < .a, .a < ret, PUBLIC < ret, .a < ret, PUBLIC < ret]
+  Locals:
+    lvars: {}
+    pc: pc
+Constraints:
+  [A < .a, \C < .a, .a < ret, PUBLIC < ret, .a < ret, PUBLIC < ret]
 
 Analyzing \dbl:
-* pc: pc
-* This: None
-* Return: <ret>
-* Params: { $x -> <$x> }
-* Final environment:
-  Deps: {}
-  Locals: { $x -> <$x'1> }
-  Constraints:
-    [$x < $x'1, $x'1 < ret]
-
-Analyzing \flow_a_to_b:
-* pc: pc
-* This: None
-* Return: <ret>
-* Params: { $c -> \C<\C, lump, a=<A>, b=?thunk> }
-* Final environment:
-  Deps: { "\\C#setb"; "\\dbl" }
-  Locals: { $c -> \C<\C, lump, a=<A>, b=?thunk>; $n -> <$n> }
-  Constraints:
-    [A < .a, \C < .a, {\dbl<pc>(<.a>): <\dbl_ret>}, \dbl_ret < $n,
-     {(this: \C<\C, lump, a=<A>, b=?thunk>)->\C#setb<pc>(<$n>): <\C#setb_ret>}]
-
-Analyzing \flow_b_to_b:
-* pc: pc
-* This: None
-* Return: <ret>
-* Params: { $c -> \C<\C, lump, a=?thunk, b=<B>> }
-* Final environment:
-  Deps: { "\\C#setb" }
-  Locals: { $c -> \C<\C, lump, a=?thunk, b=<B>> }
-  Constraints:
-    [B < .b, \C < .b,
-     {(this: \C<\C, lump, a=?thunk, b=<B>>)->\C#setb<pc>(<.b>): <\C#setb_ret>}]
-
-Analyzing \flow_bot_to_b:
-* pc: pc
-* This: None
-* Return: <ret>
-* Params: { $c -> \C<\C, lump, a=?thunk, b=?thunk> }
-* Final environment:
-  Deps: { "\\C#setb"; "\\dbl" }
-  Locals: { $c -> \C<\C, lump, a=?thunk, b=?thunk> }
-  Constraints:
-    [{\dbl<pc>(<PUBLIC>): <\dbl_ret>}, {\dbl<pc>(<\dbl_ret>): <\dbl_ret'1>},
-     {(this: \C<\C, lump, a=?thunk, b=?thunk>)->\C#setb<pc>(<\dbl_ret'1>): <\C#setb_ret>}]
-
-Analyzing \indirect_flow_a_to_b:
-* pc: pc
-* This: None
-* Return: <ret>
-* Params: { $c -> \C<\C, lump, a=<A>, b=?thunk> }
-* Final environment:
-  Deps: { "\\C#setb" }
-  Locals: { $c -> \C<\C, lump, a=<A>, b=?thunk> }
-  Constraints:
-    [A < .a, \C < .a, .a < pcjoin, pc < pcjoin,
-     {(this: \C<\C, lump, a=<A>, b=?thunk>)->\C#setb<pcjoin>(<PUBLIC>): <\C#setb_ret>}]
-
-Analyzing \indirect_flow_a_to_b_bis:
-* pc: pc
 * This: None
 * Return: <ret>
 * Params:
+  lvars: { $x -> <$x> }
+  pc: pc
+* Final environment:
+  Deps: {}
+  Locals:
+    lvars: { $x -> <$x'1> }
+    pc: pc
+Constraints:
+  [$x < $x'1, $x'1 < ret]
+
+Analyzing \flow_a_to_b:
+* This: None
+* Return: <ret>
+* Params:
+  lvars: { $c -> \C<\C, lump, a=<A>, b=?thunk> }
+  pc: pc
+* Final environment:
+  Deps: { "\\C#setb"; "\\dbl" }
+  Locals:
+    lvars: { $c -> \C<\C, lump, a=<A>, b=?thunk>; $n -> <$n> }
+    pc: pc
+Constraints:
+  [A < .a, \C < .a, {\dbl<pc>(<.a>): <\dbl_ret>}, \dbl_ret < $n,
+   {(this: \C<\C, lump, a=<A>, b=?thunk>)->\C#setb<pc>(<$n>): <\C#setb_ret>}]
+
+Analyzing \flow_b_to_b:
+* This: None
+* Return: <ret>
+* Params:
+  lvars: { $c -> \C<\C, lump, a=?thunk, b=<B>> }
+  pc: pc
+* Final environment:
+  Deps: { "\\C#setb" }
+  Locals:
+    lvars: { $c -> \C<\C, lump, a=?thunk, b=<B>> }
+    pc: pc
+Constraints:
+  [B < .b, \C < .b,
+   {(this: \C<\C, lump, a=?thunk, b=<B>>)->\C#setb<pc>(<.b>): <\C#setb_ret>}]
+
+Analyzing \flow_bot_to_b:
+* This: None
+* Return: <ret>
+* Params:
+  lvars: { $c -> \C<\C, lump, a=?thunk, b=?thunk> }
+  pc: pc
+* Final environment:
+  Deps: { "\\C#setb"; "\\dbl" }
+  Locals:
+    lvars: { $c -> \C<\C, lump, a=?thunk, b=?thunk> }
+    pc: pc
+Constraints:
+  [{\dbl<pc>(<PUBLIC>): <\dbl_ret>}, {\dbl<pc>(<\dbl_ret>): <\dbl_ret'1>},
+   {(this: \C<\C, lump, a=?thunk, b=?thunk>)->\C#setb<pc>(<\dbl_ret'1>): <\C#setb_ret>}]
+
+Analyzing \indirect_flow_a_to_b:
+* This: None
+* Return: <ret>
+* Params:
+  lvars: { $c -> \C<\C, lump, a=<A>, b=?thunk> }
+  pc: pc
+* Final environment:
+  Deps: { "\\C#setb" }
+  Locals:
+    lvars: { $c -> \C<\C, lump, a=<A>, b=?thunk> }
+    pc: pc
+Constraints:
+  [A < .a, \C < .a, .a < pcjoin, pc < pcjoin,
+   {(this: \C<\C, lump, a=<A>, b=?thunk>)->\C#setb<pcjoin>(<PUBLIC>): <\C#setb_ret>}]
+
+Analyzing \indirect_flow_a_to_b_bis:
+* This: None
+* Return: <ret>
+* Params:
+  lvars:
     { $c1 -> \C<\C, lump, a=?thunk, b=?thunk>;
       $c2 -> \C<\C'1, lump'1, a=?thunk, b=<B>> }
+  pc: pc
 * Final environment:
   Deps: { "\\C#is_a_pos"; "\\C#setb" }
   Locals:
-    { $c1 -> \C<\C, lump, a=?thunk, b=?thunk>;
-      $c2 -> \C<\C'1, lump'1, a=?thunk, b=<B>> }
-  Constraints:
-    [{(this: \C<\C, lump, a=?thunk, b=?thunk>)->\C#is_a_pos<pc>(): <\C#is_a_pos_ret>},
-     B < .b, \C'1 < .b, \C#is_a_pos_ret < pcjoin, pc < pcjoin,
-     {(this: \C<\C'1, lump'1, a=?thunk, b=<B>>)->\C#setb<pcjoin>(<.b>): <\C#setb_ret>}]
+    lvars:
+      { $c1 -> \C<\C, lump, a=?thunk, b=?thunk>;
+        $c2 -> \C<\C'1, lump'1, a=?thunk, b=<B>> }
+    pc: pc
+Constraints:
+  [{(this: \C<\C, lump, a=?thunk, b=?thunk>)->\C#is_a_pos<pc>(): <\C#is_a_pos_ret>},
+   B < .b, \C'1 < .b, \C#is_a_pos_ret < pcjoin, pc < pcjoin,
+   {(this: \C<\C'1, lump'1, a=?thunk, b=<B>>)->\C#setb<pcjoin>(<.b>): <\C#setb_ret>}]
 
 Flow constraints for \C#is_a_pos:
   

--- a/hphp/hack/test/ifc/analysis/generic.php.exp
+++ b/hphp/hack/test/ifc/analysis/generic.php.exp
@@ -4,16 +4,18 @@ Decls:
   function \test: { kind = public }
   
 Analyzing \test:
-* pc: pc
 * This: None
 * Return: \G<<tp>, <tp'1>, <tp'2>><\G, lump>
-* Params: { $g -> \G<<tp'3>, <tp'4>, <tp'5>><\G'1, lump'1> }
+* Params:
+  lvars: { $g -> \G<<tp'3>, <tp'4>, <tp'5>><\G'1, lump'1> }
+  pc: pc
 * Final environment:
   Deps: {}
-  Locals: { $g -> \G<<tp'3>, <tp'4>, <tp'5>><\G'1, lump'1> }
-  Constraints:
-    [tp'3 < tp, tp'1 < tp'4, tp'2 < tp'5, tp'5 < tp'2, lump'1 = lump,
-     \G'1 < \G]
+  Locals:
+    lvars: { $g -> \G<<tp'3>, <tp'4>, <tp'5>><\G'1, lump'1> }
+    pc: pc
+Constraints:
+  [tp'3 < tp, tp'1 < tp'4, tp'2 < tp'5, tp'5 < tp'2, lump'1 = lump, \G'1 < \G]
 
 Flow constraints for \test:
   

--- a/hphp/hack/test/ifc/analysis/property.php.exp
+++ b/hphp/hack/test/ifc/analysis/property.php.exp
@@ -12,127 +12,151 @@ Decls:
   function \tlSetOtherBool: { kind = public }
   
 Analyzing __construct:
-* pc: pc
 * This:
     \My<\My, lump, mInt=<.mInt>,
           other=\Other<\Other'1, lump'2, oBool=<.oBool>>>
 * Return: <ret>
 * Params:
+  lvars:
     { $mBool -> <$mBool>;
       $mInt -> <$mInt>;
       $other -> \Other<\Other, lump'1, oBool=<.oBool'1>> }
+  pc: pc
 * Final environment:
   Deps: {}
   Locals:
-    { $mBool -> <$mBool>;
-      $mInt -> <$mInt>;
-      $other -> \Other<\Other, lump'1, oBool=<.oBool'1>> }
-  Constraints:
-    [\My < .mInt, $mInt < .mInt, pc < .mInt, \My < \Other'1,
-     .oBool < .oBool'1, .oBool'1 < .oBool, lump'1 = lump'2,
-     \Other < \Other'1, pc < \Other'1, \My < lump, $mBool < lump, pc < lump]
+    lvars:
+      { $mBool -> <$mBool>;
+        $mInt -> <$mInt>;
+        $other -> \Other<\Other, lump'1, oBool=<.oBool'1>> }
+    pc: pc
+Constraints:
+  [\My < .mInt, $mInt < .mInt, pc < .mInt, \My < \Other'1, .oBool < .oBool'1,
+   .oBool'1 < .oBool, lump'1 = lump'2, \Other < \Other'1, pc < \Other'1,
+   \My < lump, $mBool < lump, pc < lump]
 
 Analyzing getMInt:
-* pc: pc
 * This: \My<\My, lump, mInt=<.mInt>, other=?thunk>
 * Return: <ret>
-* Params: {}
+* Params:
+  lvars: {}
+  pc: pc
 * Final environment:
   Deps: {}
-  Locals: {}
-  Constraints:
-    [.mInt < .mInt'1, \My < .mInt'1, .mInt'1 < ret]
+  Locals:
+    lvars: {}
+    pc: pc
+Constraints:
+  [.mInt < .mInt'1, \My < .mInt'1, .mInt'1 < ret]
 
 Analyzing setMInt:
-* pc: pc
 * This: \My<\My, lump, mInt=<.mInt>, other=?thunk>
 * Return: <ret>
-* Params: { $candidate -> <$candidate> }
+* Params:
+  lvars: { $candidate -> <$candidate> }
+  pc: pc
 * Final environment:
   Deps: {}
-  Locals: { $candidate -> <$candidate> }
-  Constraints:
-    [\My < .mInt, $candidate < .mInt, pc < .mInt]
+  Locals:
+    lvars: { $candidate -> <$candidate> }
+    pc: pc
+Constraints:
+  [\My < .mInt, $candidate < .mInt, pc < .mInt]
 
 Analyzing \tlGetMyInt:
-* pc: pc
-* This: None
-* Return: <ret>
-* Params: { $obj -> \My<\My, lump, mInt=<.mInt>, other=?thunk> }
-* Final environment:
-  Deps: {}
-  Locals: { $obj -> \My<\My, lump, mInt=<.mInt>, other=?thunk> }
-  Constraints:
-    [.mInt < .mInt'1, \My < .mInt'1, .mInt'1 < ret]
-
-Analyzing \tlSetMyInt:
-* pc: pc
 * This: None
 * Return: <ret>
 * Params:
-    { $obj -> \My<\My, lump, mInt=<.mInt>, other=?thunk>; $val -> <$val> }
+  lvars: { $obj -> \My<\My, lump, mInt=<.mInt>, other=?thunk> }
+  pc: pc
 * Final environment:
   Deps: {}
   Locals:
+    lvars: { $obj -> \My<\My, lump, mInt=<.mInt>, other=?thunk> }
+    pc: pc
+Constraints:
+  [.mInt < .mInt'1, \My < .mInt'1, .mInt'1 < ret]
+
+Analyzing \tlSetMyInt:
+* This: None
+* Return: <ret>
+* Params:
+  lvars:
     { $obj -> \My<\My, lump, mInt=<.mInt>, other=?thunk>; $val -> <$val> }
-  Constraints:
-    [\My < .mInt, $val < .mInt, pc < .mInt]
+  pc: pc
+* Final environment:
+  Deps: {}
+  Locals:
+    lvars:
+      { $obj -> \My<\My, lump, mInt=<.mInt>, other=?thunk>; $val -> <$val> }
+    pc: pc
+Constraints:
+  [\My < .mInt, $val < .mInt, pc < .mInt]
 
 Analyzing \tlGetOther:
-* pc: pc
 * This: None
 * Return: \Other<\Other, lump, oBool=<.oBool>>
 * Params:
+  lvars:
     { $obj ->
       \My<\My, lump'1, mInt=?thunk,
             other=\Other<\Other'1, lump'2, oBool=<.oBool'1>>> }
+  pc: pc
 * Final environment:
   Deps: {}
   Locals:
-    { $obj ->
-      \My<\My, lump'1, mInt=?thunk,
-            other=\Other<\Other'1, lump'2, oBool=<.oBool'1>>> }
-  Constraints:
-    [\Other'1 < .other, \My < .other, .oBool < .oBool'1, .oBool'1 < .oBool,
-     lump'2 = lump, .other < \Other]
+    lvars:
+      { $obj ->
+        \My<\My, lump'1, mInt=?thunk,
+              other=\Other<\Other'1, lump'2, oBool=<.oBool'1>>> }
+    pc: pc
+Constraints:
+  [\Other'1 < .other, \My < .other, .oBool < .oBool'1, .oBool'1 < .oBool,
+   lump'2 = lump, .other < \Other]
 
 Analyzing \tlGetOtherBool:
-* pc: pc
 * This: None
 * Return: <ret>
 * Params:
+  lvars:
     { $obj ->
       \My<\My, lump, mInt=?thunk,
             other=\Other<\Other, lump'1, oBool=<.oBool>>> }
+  pc: pc
 * Final environment:
   Deps: {}
   Locals:
-    { $obj ->
-      \My<\My, lump, mInt=?thunk,
-            other=\Other<\Other, lump'1, oBool=<.oBool>>> }
-  Constraints:
-    [\Other < .other, \My < .other, .oBool < .oBool'1, .other < .oBool'1,
-     .oBool'1 < ret]
+    lvars:
+      { $obj ->
+        \My<\My, lump, mInt=?thunk,
+              other=\Other<\Other, lump'1, oBool=<.oBool>>> }
+    pc: pc
+Constraints:
+  [\Other < .other, \My < .other, .oBool < .oBool'1, .other < .oBool'1,
+   .oBool'1 < ret]
 
 Analyzing \tlSetOtherBool:
-* pc: pc
 * This: None
 * Return: <ret>
 * Params:
+  lvars:
     { $bool -> <$bool>;
       $obj ->
       \My<\My, lump, mInt=?thunk,
             other=\Other<\Other, lump'1, oBool=<.oBool>>> }
+  pc: pc
 * Final environment:
   Deps: {}
   Locals:
-    { $bool -> <$bool>;
-      $obj ->
-      \My<\My, lump, mInt=?thunk,
-            other=\Other<\Other, lump'1, oBool=<.oBool>>> }
-  Constraints:
-    [\Other < .other, \My < .other, .other < .oBool, $bool < .oBool,
-     pc < .oBool]
+    lvars:
+      { $bool -> <$bool>;
+        $obj ->
+        \My<\My, lump, mInt=?thunk,
+              other=\Other<\Other, lump'1, oBool=<.oBool>>> }
+    pc: pc
+Constraints:
+  [\Other < .other, \My < .other, .other < .oBool, $bool < .oBool,
+   pc < .oBool]
 
 Flow constraints for \My#__construct:
   

--- a/hphp/hack/test/ifc/analysis/purpose.php.exp
+++ b/hphp/hack/test/ifc/analysis/purpose.php.exp
@@ -10,71 +10,89 @@ Decls:
   function \D#__construct: { kind = public }
   
 Analyzing __construct:
-* pc: pc
 * This: \D<\D, lump>
 * Return: <ret>
-* Params: { $di -> <$di> }
+* Params:
+  lvars: { $di -> <$di> }
+  pc: pc
 * Final environment:
   Deps: {}
-  Locals: { $di -> <$di> }
-  Constraints:
-    [\D < lump, $di < lump, pc < lump]
+  Locals:
+    lvars: { $di -> <$di> }
+    pc: pc
+Constraints:
+  [\D < lump, $di < lump, pc < lump]
 
 Analyzing __construct:
-* pc: pc
 * This: \C<\C, lump, ci=<SECRET>, d=\D<SECRET, SECRET>>
 * Return: <ret>
-* Params: { $ci -> <$ci>; $d -> \D<\D, lump'1> }
+* Params:
+  lvars: { $ci -> <$ci>; $d -> \D<\D, lump'1> }
+  pc: pc
 * Final environment:
   Deps: {}
-  Locals: { $ci -> <$ci>; $d -> \D<\D, lump'1> }
-  Constraints:
-    [\C < SECRET, $ci < SECRET, pc < SECRET, \C < SECRET, lump'1 = SECRET,
-     \D < SECRET, pc < SECRET]
+  Locals:
+    lvars: { $ci -> <$ci>; $d -> \D<\D, lump'1> }
+    pc: pc
+Constraints:
+  [\C < SECRET, $ci < SECRET, pc < SECRET, \C < SECRET, lump'1 = SECRET,
+   \D < SECRET, pc < SECRET]
 
 Analyzing getShallow1:
-* pc: pc
 * This: \C<\C, lump, ci=<SECRET>, d=?thunk>
 * Return: <ret>
-* Params: {}
+* Params:
+  lvars: {}
+  pc: pc
 * Final environment:
   Deps: {}
-  Locals: {}
-  Constraints:
-    [SECRET < .ci, \C < .ci, .ci < ret]
+  Locals:
+    lvars: {}
+    pc: pc
+Constraints:
+  [SECRET < .ci, \C < .ci, .ci < ret]
 
 Analyzing getShallow2:
-* pc: pc
 * This: \C<\C, lump, ci=?thunk, d=\D<SECRET, SECRET>>
 * Return: \D<\D, lump'1>
-* Params: {}
+* Params:
+  lvars: {}
+  pc: pc
 * Final environment:
   Deps: {}
-  Locals: {}
-  Constraints:
-    [SECRET < .d, \C < .d, SECRET = lump'1, .d < \D]
+  Locals:
+    lvars: {}
+    pc: pc
+Constraints:
+  [SECRET < .d, \C < .d, SECRET = lump'1, .d < \D]
 
 Analyzing getDeep:
-* pc: pc
 * This: \C<\C, lump, ci=?thunk, d=\D<SECRET, SECRET>>
 * Return: <ret>
-* Params: {}
+* Params:
+  lvars: {}
+  pc: pc
 * Final environment:
   Deps: {}
-  Locals: {}
-  Constraints:
-    [SECRET < .d, \C < .d, SECRET < .di, .d < .di, .di < ret]
+  Locals:
+    lvars: {}
+    pc: pc
+Constraints:
+  [SECRET < .d, \C < .d, SECRET < .di, .d < .di, .di < ret]
 
 Analyzing writeDeep:
-* pc: pc
 * This: \C<\C, lump, ci=?thunk, d=\D<SECRET, SECRET>>
 * Return: <ret>
-* Params: {}
+* Params:
+  lvars: {}
+  pc: pc
 * Final environment:
   Deps: {}
-  Locals: {}
-  Constraints:
-    [SECRET < .d, \C < .d, .d < SECRET, PUBLIC < SECRET, pc < SECRET]
+  Locals:
+    lvars: {}
+    pc: pc
+Constraints:
+  [SECRET < .d, \C < .d, .d < SECRET, PUBLIC < SECRET, pc < SECRET]
 
 Flow constraints for \C#__construct:
   

--- a/hphp/hack/test/ifc/analysis/recursive_class.php.exp
+++ b/hphp/hack/test/ifc/analysis/recursive_class.php.exp
@@ -6,40 +6,49 @@ Decls:
   function \R#recursiveWrite: { kind = public }
   
 Analyzing __construct:
-* pc: pc
 * This: \R<\R, lump>
 * Return: <ret>
-* Params: { $prop -> <$prop>; $r -> \R<\R'1, lump'1> }
+* Params:
+  lvars: { $prop -> <$prop>; $r -> \R<\R'1, lump'1> }
+  pc: pc
 * Final environment:
   Deps: {}
-  Locals: { $prop -> <$prop>; $r -> \R<\R'1, lump'1> }
-  Constraints:
-    [\R < lump, $prop < lump, pc < lump, \R < lump, lump'1 = lump,
-     \R'1 < lump, pc < lump]
+  Locals:
+    lvars: { $prop -> <$prop>; $r -> \R<\R'1, lump'1> }
+    pc: pc
+Constraints:
+  [\R < lump, $prop < lump, pc < lump, \R < lump, lump'1 = lump, \R'1 < lump,
+   pc < lump]
 
 Analyzing recursiveGet:
-* pc: pc
 * This: \R<\R, lump>
 * Return: <ret>
-* Params: {}
+* Params:
+  lvars: {}
+  pc: pc
 * Final environment:
   Deps: {}
-  Locals: {}
-  Constraints:
-    [lump < .r, \R < .r, lump < .r'1, .r < .r'1, lump < .r'2, .r'1 < .r'2,
-     lump < .prop, .r'2 < .prop, .prop < ret]
+  Locals:
+    lvars: {}
+    pc: pc
+Constraints:
+  [lump < .r, \R < .r, lump < .r'1, .r < .r'1, lump < .r'2, .r'1 < .r'2,
+   lump < .prop, .r'2 < .prop, .prop < ret]
 
 Analyzing recursiveWrite:
-* pc: pc
 * This: \R<\R, lump>
 * Return: <ret>
-* Params: {}
+* Params:
+  lvars: {}
+  pc: pc
 * Final environment:
   Deps: {}
-  Locals: {}
-  Constraints:
-    [lump < .r, \R < .r, lump < .r'1, .r < .r'1, lump < .r'2, .r'1 < .r'2,
-     .r'2 < lump, PUBLIC < lump, pc < lump]
+  Locals:
+    lvars: {}
+    pc: pc
+Constraints:
+  [lump < .r, \R < .r, lump < .r'1, .r < .r'1, lump < .r'2, .r'1 < .r'2,
+   .r'2 < lump, PUBLIC < lump, pc < lump]
 
 Flow constraints for \R#__construct:
   

--- a/hphp/hack/test/ifc/analysis/unpolicied_fields.php.exp
+++ b/hphp/hack/test/ifc/analysis/unpolicied_fields.php.exp
@@ -9,61 +9,76 @@ Decls:
   function \D#__construct: { kind = public }
   
 Analyzing __construct:
-* pc: pc
 * This: \C<\C, lump, cx=<.cx>>
 * Return: <ret>
-* Params: { $cd -> \D<\D, lump'1>; $cx -> <$cx>; $cy -> <$cy> }
+* Params:
+  lvars: { $cd -> \D<\D, lump'1>; $cx -> <$cx>; $cy -> <$cy> }
+  pc: pc
 * Final environment:
   Deps: {}
-  Locals: { $cd -> \D<\D, lump'1>; $cx -> <$cx>; $cy -> <$cy> }
-  Constraints:
-    [\C < .cx, $cx < .cx, pc < .cx, \C < lump, $cy < lump, pc < lump,
-     \C < lump, lump'1 = lump, \D < lump, pc < lump]
+  Locals:
+    lvars: { $cd -> \D<\D, lump'1>; $cx -> <$cx>; $cy -> <$cy> }
+    pc: pc
+Constraints:
+  [\C < .cx, $cx < .cx, pc < .cx, \C < lump, $cy < lump, pc < lump,
+   \C < lump, lump'1 = lump, \D < lump, pc < lump]
 
 Analyzing testGetUnpolicied:
-* pc: pc
 * This: \C<\C, lump, cx=?thunk>
 * Return: \D<\D, lump'1>
-* Params: {}
+* Params:
+  lvars: {}
+  pc: pc
 * Final environment:
   Deps: {}
-  Locals: {}
-  Constraints:
-    [lump < .cd, \C < .cd, lump = lump'1, .cd < \D]
+  Locals:
+    lvars: {}
+    pc: pc
+Constraints:
+  [lump < .cd, \C < .cd, lump = lump'1, .cd < \D]
 
 Analyzing testSetMultipleUnpolicied:
-* pc: pc
 * This: \C<\C, lump, cx=?thunk>
 * Return: <ret>
-* Params: { $d -> \D<\D, lump'1> }
+* Params:
+  lvars: { $d -> \D<\D, lump'1> }
+  pc: pc
 * Final environment:
   Deps: {}
-  Locals: { $d -> \D<\D, lump'1> }
-  Constraints:
-    [\C < lump, PUBLIC < lump, pc < lump, \C < lump, lump'1 = lump,
-     \D < lump, pc < lump]
+  Locals:
+    lvars: { $d -> \D<\D, lump'1> }
+    pc: pc
+Constraints:
+  [\C < lump, PUBLIC < lump, pc < lump, \C < lump, lump'1 = lump, \D < lump,
+   pc < lump]
 
 Analyzing testSetDeep:
-* pc: pc
 * This: \C<\C, lump, cx=?thunk>
 * Return: <ret>
-* Params: { $i -> <$i> }
+* Params:
+  lvars: { $i -> <$i> }
+  pc: pc
 * Final environment:
   Deps: {}
-  Locals: { $i -> <$i> }
-  Constraints:
-    [lump < .cd, \C < .cd, .cd < lump, $i < lump, pc < lump]
+  Locals:
+    lvars: { $i -> <$i> }
+    pc: pc
+Constraints:
+  [lump < .cd, \C < .cd, .cd < lump, $i < lump, pc < lump]
 
 Analyzing __construct:
-* pc: pc
 * This: \D<\D, lump>
 * Return: <ret>
-* Params: { $di -> <$di> }
+* Params:
+  lvars: { $di -> <$di> }
+  pc: pc
 * Final environment:
   Deps: {}
-  Locals: { $di -> <$di> }
-  Constraints:
-    [\D < lump, $di < lump, pc < lump]
+  Locals:
+    lvars: { $di -> <$di> }
+    pc: pc
+Constraints:
+  [\D < lump, $di < lump, pc < lump]
 
 Flow constraints for \C#__construct:
   

--- a/hphp/hack/test/ifc/analysis/vec.php.exp
+++ b/hphp/hack/test/ifc/analysis/vec.php.exp
@@ -12,122 +12,148 @@ Decls:
   function \testCollection: { kind = public }
   
 Analyzing \empty:
-* pc: pc
 * This: None
 * Return: \HH\vec<<tp>><\HH\vec, lump>
-* Params: {}
+* Params:
+  lvars: {}
+  pc: pc
 * Final environment:
   Deps: {}
-  Locals: { $vec -> \HH\vec<nothing><\HH\vec'2, lump'2> }
-  Constraints:
-    [lump'1 = lump'2, \HH\vec'1 < \HH\vec'2, lump'2 = lump,
-     \HH\vec'2 < \HH\vec]
+  Locals:
+    lvars: { $vec -> \HH\vec<nothing><\HH\vec'2, lump'2> }
+    pc: pc
+Constraints:
+  [lump'1 = lump'2, \HH\vec'1 < \HH\vec'2, lump'2 = lump, \HH\vec'2 < \HH\vec]
 
 Analyzing \testCollection:
-* pc: pc
 * This: None
 * Return: \HH\vec<<tp>><\HH\vec, lump>
-* Params: {}
+* Params:
+  lvars: {}
+  pc: pc
 * Final environment:
   Deps: {}
-  Locals: { $there -> <$there>; $vec -> \HH\vec<<tp'2>><\HH\vec'2, lump'2> }
-  Constraints:
-    [PUBLIC < $there, PUBLIC < tp'1, $there < tp'1, tp'1 < tp'2,
-     lump'1 = lump'2, \HH\vec'1 < \HH\vec'2, tp'2 < tp, lump'2 = lump,
-     \HH\vec'2 < \HH\vec]
+  Locals:
+    lvars: { $there -> <$there>; $vec -> \HH\vec<<tp'2>><\HH\vec'2, lump'2> }
+    pc: pc
+Constraints:
+  [PUBLIC < $there, PUBLIC < tp'1, $there < tp'1, tp'1 < tp'2,
+   lump'1 = lump'2, \HH\vec'1 < \HH\vec'2, tp'2 < tp, lump'2 = lump,
+   \HH\vec'2 < \HH\vec]
 
 Analyzing \testAdd1:
-* pc: pc
 * This: None
 * Return: <ret>
-* Params: { $vec -> \HH\vec<<tp>><\HH\vec, lump> }
+* Params:
+  lvars: { $vec -> \HH\vec<<tp>><\HH\vec, lump> }
+  pc: pc
 * Final environment:
   Deps: {}
-  Locals: { $vec -> \HH\vec<<tp'1>><\HH\vec'1, lump'1> }
-  Constraints:
-    [tp < tp'1, lump = lump'1, \HH\vec < \HH\vec'1, PUBLIC < tp'1]
+  Locals:
+    lvars: { $vec -> \HH\vec<<tp'1>><\HH\vec'1, lump'1> }
+    pc: pc
+Constraints:
+  [tp < tp'1, lump = lump'1, \HH\vec < \HH\vec'1, PUBLIC < tp'1]
 
 Analyzing \testAdd2:
-* pc: pc
 * This: None
 * Return: <ret>
-* Params: {}
+* Params:
+  lvars: {}
+  pc: pc
 * Final environment:
   Deps: {}
-  Locals: { $vec -> \HH\vec<<tp'2>><\HH\vec'2, lump'2> }
-  Constraints:
-    [PUBLIC < tp, PUBLIC < tp, tp < tp'1, lump = lump'1, \HH\vec < \HH\vec'1,
-     tp'1 < tp'2, lump'1 = lump'2, \HH\vec'1 < \HH\vec'2, PUBLIC < tp'2]
+  Locals:
+    lvars: { $vec -> \HH\vec<<tp'2>><\HH\vec'2, lump'2> }
+    pc: pc
+Constraints:
+  [PUBLIC < tp, PUBLIC < tp, tp < tp'1, lump = lump'1, \HH\vec < \HH\vec'1,
+   tp'1 < tp'2, lump'1 = lump'2, \HH\vec'1 < \HH\vec'2, PUBLIC < tp'2]
 
 Analyzing \retElem:
-* pc: pc
 * This: None
 * Return: <ret>
-* Params: {}
+* Params:
+  lvars: {}
+  pc: pc
 * Final environment:
   Deps: {}
-  Locals: { $vec -> \HH\vec<<tp'1>><\HH\vec'1, lump'1> }
-  Constraints:
-    [PUBLIC < tp, PUBLIC < tp, PUBLIC < tp, tp < tp'1, lump = lump'1,
-     \HH\vec < \HH\vec'1, tp'1 < ret]
+  Locals:
+    lvars: { $vec -> \HH\vec<<tp'1>><\HH\vec'1, lump'1> }
+    pc: pc
+Constraints:
+  [PUBLIC < tp, PUBLIC < tp, PUBLIC < tp, tp < tp'1, lump = lump'1,
+   \HH\vec < \HH\vec'1, tp'1 < ret]
 
 Analyzing set:
-* pc: pc
-* This: \C<\C, lump, i=<INT>, v=\HH\vec<<VEC>><VEC, VEC>>
-* Return: <ret>
-* Params: {}
-* Final environment:
-  Deps: {}
-  Locals: {}
-  Constraints:
-    [INT < .i, \C < .i, VEC < .v, VEC < .v'1, \C < .v, \C < VEC, .v'1 < VEC,
-     VEC = VEC, .v < VEC, .i < VEC, pc < VEC]
-
-Analyzing nested:
-* pc: pc
 * This: \C<\C, lump, i=<INT>, v=\HH\vec<<VEC>><VEC, VEC>>
 * Return: <ret>
 * Params:
-    { $vv -> \HH\vec<\HH\vec<<tp>><\HH\vec, lump'2>><\HH\vec'1, lump'1> }
+  lvars: {}
+  pc: pc
 * Final environment:
   Deps: {}
   Locals:
-    { $vv -> \HH\vec<\HH\vec<<tp'1>><\HH\vec'2, lump'4>><\HH\vec'3, lump'3> }
-  Constraints:
-    [VEC < .v, VEC < .v'1, \C < .v, tp < tp'1, lump'2 = lump'4,
-     \HH\vec < \HH\vec'2, lump'1 = lump'3, \HH\vec'1 < \HH\vec'3, tp < tp'1,
-     lump'2 = lump'4, \HH\vec < \HH\vec'2, .v'1 < tp'1, \C < INT, tp'1 < INT,
-     pc < INT]
+    lvars: {}
+    pc: pc
+Constraints:
+  [INT < .i, \C < .i, VEC < .v, VEC < .v'1, \C < .v, \C < VEC, .v'1 < VEC,
+   VEC = VEC, .v < VEC, .i < VEC, pc < VEC]
 
-Analyzing mutation:
-* pc: pc
+Analyzing nested:
 * This: \C<\C, lump, i=<INT>, v=\HH\vec<<VEC>><VEC, VEC>>
 * Return: <ret>
-* Params: {}
-* Final environment:
-  Deps: {}
-  Locals: {}
-  Constraints:
-    [VEC < .v, VEC < .v'1, \C < .v, INT < .i, \C < .i, .v'1 < bop, .i < bop,
-     VEC < .v'2, VEC < .v'3, \C < .v'2, \C < VEC, .v'3 < VEC, VEC = VEC,
-     .v'2 < VEC, bop < VEC, pc < VEC]
-
-Analyzing \copyOnWrite:
-* pc: pc
-* This: None
-* Return: <ret>
-* Params: { $v -> \HH\vec<<tp>><\HH\vec, lump>; $x -> <$x>; $y -> <$y> }
+* Params:
+  lvars:
+    { $vv -> \HH\vec<\HH\vec<<tp>><\HH\vec, lump'2>><\HH\vec'1, lump'1> }
+  pc: pc
 * Final environment:
   Deps: {}
   Locals:
-    { $v -> \HH\vec<<tp'3>><\HH\vec'3, lump'3>;
-      $vx -> \HH\vec<<tp'2>><\HH\vec'2, lump'2>;
-      $x -> <$x>;
-      $y -> <$y> }
-  Constraints:
-    [tp < tp'1, lump = lump'1, \HH\vec < \HH\vec'1, $x < tp'1, tp'1 < tp'2,
-     lump'1 = lump'2, \HH\vec'1 < \HH\vec'2, tp'1 < tp'3, lump'1 = lump'3,
-     \HH\vec'1 < \HH\vec'3, $y < tp'3]
+    lvars:
+      { $vv -> \HH\vec<\HH\vec<<tp'1>><\HH\vec'2, lump'4>><\HH\vec'3, lump'3> }
+    pc: pc
+Constraints:
+  [VEC < .v, VEC < .v'1, \C < .v, tp < tp'1, lump'2 = lump'4,
+   \HH\vec < \HH\vec'2, lump'1 = lump'3, \HH\vec'1 < \HH\vec'3, tp < tp'1,
+   lump'2 = lump'4, \HH\vec < \HH\vec'2, .v'1 < tp'1, \C < INT, tp'1 < INT,
+   pc < INT]
+
+Analyzing mutation:
+* This: \C<\C, lump, i=<INT>, v=\HH\vec<<VEC>><VEC, VEC>>
+* Return: <ret>
+* Params:
+  lvars: {}
+  pc: pc
+* Final environment:
+  Deps: {}
+  Locals:
+    lvars: {}
+    pc: pc
+Constraints:
+  [VEC < .v, VEC < .v'1, \C < .v, INT < .i, \C < .i, .v'1 < bop, .i < bop,
+   VEC < .v'2, VEC < .v'3, \C < .v'2, \C < VEC, .v'3 < VEC, VEC = VEC,
+   .v'2 < VEC, bop < VEC, pc < VEC]
+
+Analyzing \copyOnWrite:
+* This: None
+* Return: <ret>
+* Params:
+  lvars: { $v -> \HH\vec<<tp>><\HH\vec, lump>; $x -> <$x>; $y -> <$y> }
+  pc: pc
+* Final environment:
+  Deps: {}
+  Locals:
+    lvars:
+      { $v -> \HH\vec<<tp'3>><\HH\vec'3, lump'3>;
+        $vx -> \HH\vec<<tp'2>><\HH\vec'2, lump'2>;
+        $x -> <$x>;
+        $y -> <$y> }
+    pc: pc
+Constraints:
+  [tp < tp'1, lump = lump'1, \HH\vec < \HH\vec'1, $x < tp'1, tp'1 < tp'2,
+   lump'1 = lump'2, \HH\vec'1 < \HH\vec'2, tp'1 < tp'3, lump'1 = lump'3,
+   \HH\vec'1 < \HH\vec'3, $y < tp'3]
 
 Flow constraints for \C#mutation:
   


### PR DESCRIPTION
Summary: We need to make the local and global program counters mutable so that we can add pc dependencies based on throwing exceptions and early returns from an if block. To achieve this, I have moved them to the continuation map rather than the immutable read-only environment

Reviewed By: mpu

Differential Revision: D22335572

fbshipit-source-id: c0129d877a031b6eab5c2ac086fc883b9963f63d